### PR TITLE
Configurable MaxFlushInterval for RawDataReporter

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
@@ -251,7 +251,7 @@ namespace NServiceBus.Metrics.ServiceControl
                     }
                 }
 
-                return new RawDataReporter(Sender, buffer, (entries, binaryWriter) => writer.Write(binaryWriter, entries));
+                return new RawDataReporter(Sender, buffer, (entries, binaryWriter) => writer.Write(binaryWriter, entries), 2048, options.ServiceControlReportingInterval);
             }
 
             protected override async Task OnStop(IMessageSession session)


### PR DESCRIPTION
## Overview
This PR uses `interval` parameter value from `SendMetricDataToServiceControl` as `MaxFlushInterval` in `RawDataReporter`. This way users are able to control maximum delay for sending monitoring data. 

## Behavior
The advantage is that for users there is a single parameter to choose and values in range of seconds make sense for both parameters. 

This has a downside of enabling users to control snapshot metrics reporting (Queue length) separately from raw data reporting. That however does not seem to be a big problem in practice. Let's discus two extreme scenarios:
   * Low traffic endpoint - If we configure `interval` to x seconds it means that monitoring data will be sent both for snapshot and raw data with at most x seconds delay
   * High traffic endpoints - if we configure `interval` to x seconds it means that monitoring data will be sent for snapshot data with delay of x seconds and for raw data probably faster as the buffer reaches 2048 entries.
