### PR TITLE
Migrating CriticalTime and Retries to 1.0

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl.Tests/When_reporting_to_ServiceControl_enabled.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/When_reporting_to_ServiceControl_enabled.cs
@@ -15,6 +15,7 @@
 
     public class When_reporting_to_ServiceControl_enabled : NServiceBusAcceptanceTest
     {
+        static readonly byte[] FullyQualifiedMessageNameBytes = new UTF8Encoding(false).GetBytes(typeof(MyMessage).AssemblyQualifiedName);
         const string CustomInstanceId = "my-custom-instance";
 
         [Test]
@@ -41,8 +42,7 @@
             Assert.AreEqual("TaggedLongValueWriterOccurrence", headers["NServiceBus.ContentType"]);
 
             // dummy assert for containing the name of message in the message body
-            var fullyQualifiedName = new UTF8Encoding(false).GetBytes(typeof(MyMessage).AssemblyQualifiedName);
-            Assert.True(ContainsPattern(processingTime.Body, fullyQualifiedName), "The message should contain the fully qualified name of the reported message");
+            Assert.True(ContainsPattern(processingTime.Body, FullyQualifiedMessageNameBytes), "The message should contain the fully qualified name of the reported message");
         }
 
         static bool ContainsPattern(byte[] source, byte[] pattern)

--- a/src/NServiceBus.Metrics.ServiceControl/Buffers.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/Buffers.cs
@@ -14,13 +14,14 @@
     {
         public readonly Buffer ProcessingTime = new Buffer();
         public readonly Buffer CriticalTime = new Buffer();
+        public readonly Buffer Retries = new Buffer();
 
         static void Write(long value, string tag, Buffer buffer)
         {
             const int maxAttempts = 10;
 
             var tagId = buffer.Writer.GetTagId(tag);
-            if (buffer.Ring.TryWrite(value, tagId)) 
+            if (buffer.Ring.TryWrite(value, tagId))
             {
                 return;
             }
@@ -44,6 +45,11 @@
         public void ReportCriticalTime(TimeSpan value, string messageType)
         {
             Write((long)value.TotalMilliseconds, messageType, CriticalTime);
+        }
+
+        public void ReportRetry(string messageType)
+        {
+            Write(1, messageType, Retries);
         }
     }
 }

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlMonitoring.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlMonitoring.cs
@@ -114,6 +114,7 @@
                 reporters = new[]
                 {
                     BuildReporter("ProcessingTime", buffers.ProcessingTime),
+                    BuildReporter("CriticalTime", buffers.CriticalTime)
                 };
             }
 

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlMonitoring.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlMonitoring.cs
@@ -55,6 +55,12 @@
                 if (context.PhysicalMessage.Headers.TryGetValue(Headers.EnclosedMessageTypes, out var messageType))
                 {
                     buffers.ReportProcessingTime(processingTime, messageType);
+
+                    if (context.TryGet("IncomingMessage.TimeSent", out DateTime timeSent))
+                    {
+                        var criticalTime = ended - timeSent;
+                        buffers.ReportCriticalTime(criticalTime, messageType);
+                    }
                 }
             }
         }
@@ -105,7 +111,7 @@
             protected override void OnStart()
             {
                 var headers = CreateHeaders("ProcessingTime");
-                processingTimeReporter = new RawDataReporter(BuildSend(headers), buffers.ProcessingTimeBuffer, (entries, binaryWriter) => buffers.ProcessingTimeWriter.Write(binaryWriter, entries));
+                processingTimeReporter = new RawDataReporter(BuildSend(headers), buffers.ProcessingTime.Ring, (entries, binaryWriter) => buffers.ProcessingTime.Writer.Write(binaryWriter, entries));
                 processingTimeReporter.Start();
             }
 


### PR DESCRIPTION
This PR migrates all the metrics back to 1.0 to ensure feature parity with the recent versions (2.0, 3.0).

## PoA
- [x] Critical Time
- [x] Retries
