### PR TITLE
Introduce Time To Be Received for reporting messages to 1.0

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl.Tests/NServiceBus.Metrics.ServiceControl.approved.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/NServiceBus.Metrics.ServiceControl.approved.cs
@@ -6,6 +6,6 @@ namespace NServiceBus.Metrics.ServiceControl
     public class static BusConfigurationExtensions
     {
         public static void SendMetricDataToServiceControl(this NServiceBus.BusConfiguration busConfiguration, string serviceControlMetricsAddress, string instanceId = null) { }
-        public static void SetServiceControlTTBR(this NServiceBus.BusConfiguration busConfiguration, System.TimeSpan timeToBeReceived) { }
+        public static void SetServiceControlMetricsMessageTTBR(this NServiceBus.BusConfiguration busConfiguration, System.TimeSpan timeToBeReceived) { }
     }
 }

--- a/src/NServiceBus.Metrics.ServiceControl.Tests/NServiceBus.Metrics.ServiceControl.approved.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/NServiceBus.Metrics.ServiceControl.approved.cs
@@ -6,5 +6,6 @@ namespace NServiceBus.Metrics.ServiceControl
     public class static BusConfigurationExtensions
     {
         public static void SendMetricDataToServiceControl(this NServiceBus.BusConfiguration busConfiguration, string serviceControlMetricsAddress, string instanceId = null) { }
+        public static void SetServiceControlTTBR(this NServiceBus.BusConfiguration busConfiguration, System.TimeSpan timeToBeReceived) { }
     }
 }

--- a/src/NServiceBus.Metrics.ServiceControl.Tests/When_reporting_to_ServiceControl_expires.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/When_reporting_to_ServiceControl_expires.cs
@@ -69,7 +69,7 @@
                     var monitoringQueue = AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(MonitoringMock));
 
                     cfg.SendMetricDataToServiceControl(monitoringQueue, "my-custom-instance");
-                    cfg.SetServiceControlTTBR(TTBR);
+                    cfg.SetServiceControlMetricsMessageTTBR(TTBR);
                     cfg.Transactions().Disable(); //transactional msmq with ttbr not supported
                 });
             }

--- a/src/NServiceBus.Metrics.ServiceControl.Tests/When_reporting_to_ServiceControl_expires.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/When_reporting_to_ServiceControl_expires.cs
@@ -1,0 +1,86 @@
+﻿namespace NServiceBus.Metrics.ServiceControl.Tests
+{
+    using System;
+    using System.Threading;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using Pipeline;
+    using Pipeline.Contexts;
+
+    public class When_reporting_to_ServiceControl_expires : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_report_properly()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Sender>(b => b.Given((bus, c) =>
+                {
+                    bus.SendLocal(new MyMessage());
+                }))
+                .Done(ctx => ctx.WasCalled)
+                .WithEndpoint<MonitoringMock>()
+                .Run(TimeSpan.FromSeconds(10));
+
+            Assert.IsFalse(context.WasCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(cfg =>
+                {
+                    var queue = AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(MonitoringMock));
+                    cfg.SendMetricDataToServiceControl(queue, "my-custom-instance");
+                    cfg.SetServiceControlTTBR(TimeSpan.Zero);
+                    cfg.Transactions().Disable(); //transactional msmq with ttbr not supported
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public void Handle(MyMessage message)
+                {
+                    Thread.Sleep(100);
+                }
+            }
+        }
+
+        public class MonitoringMock : EndpointConfigurationBuilder
+        {
+            public MonitoringMock()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class MyOverride : INeedInitialization
+            {
+                public void Customize(BusConfiguration configuration)
+                {
+                    configuration.Pipeline.Replace(WellKnownStep.DeserializeMessages, typeof(MyRawMessageHandler));
+                }
+            }
+
+            class MyRawMessageHandler : IBehavior<IncomingContext>
+            {
+                public Context Context { get; set; }
+
+                public void Invoke(IncomingContext context, Action next)
+                {
+                    Context.WasCalled = true;
+                }
+            }
+        }
+
+        public class MyMessage : IMessage
+        { }
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl.Tests/When_reporting_to_ServiceControl_expires.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/When_reporting_to_ServiceControl_expires.cs
@@ -21,10 +21,11 @@
 
             Scenario.Define(context)
                 .WithEndpoint<Sender>(b => b.Given((bus, c) =>
-                  {
-                      bus.SendLocal(new MyMessage());
-                  }))
-                .Done(ctx => ctx.MessageProcessedBySender);
+                {
+                    bus.SendLocal(new MyMessage());
+                }))
+                .Done(ctx => ctx.MessageProcessedBySender)
+                .Run();
 
             Thread.Sleep(TTBR + TTBR);
 

--- a/src/NServiceBus.Metrics.ServiceControl/BusConfigurationExtensions.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/BusConfigurationExtensions.cs
@@ -26,7 +26,7 @@
         /// </summary>
         /// <param name="busConfiguration">Bus configuration.</param>
         /// <param name="timeToBeReceived">Time to be received.</param>
-        public static void SetServiceControlTTBR(this BusConfiguration busConfiguration, TimeSpan timeToBeReceived)
+        public static void SetServiceControlMetricsMessageTTBR(this BusConfiguration busConfiguration, TimeSpan timeToBeReceived)
         {
             var options = GetReportingOptions(busConfiguration);
             options.TimeToBeReceived = timeToBeReceived;

--- a/src/NServiceBus.Metrics.ServiceControl/BusConfigurationExtensions.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/BusConfigurationExtensions.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Metrics.ServiceControl
 {
+    using System;
     using Configuration.AdvanceExtensibility;
 
     /// <summary>
@@ -15,16 +16,21 @@
         /// <param name="instanceId">A custom instance id used for reporting.</param>
         public static void SendMetricDataToServiceControl(this BusConfiguration busConfiguration, string serviceControlMetricsAddress, string instanceId = null)
         {
+            var options = GetReportingOptions(busConfiguration);
+            options.ServiceControlMetricsAddress = serviceControlMetricsAddress;
+            options.EndpointInstanceIdOverride = instanceId;
+        }
+
+        static ReportingOptions GetReportingOptions(BusConfiguration busConfiguration)
+        {
             var settings = busConfiguration.GetSettings();
 
-            if (settings.TryGet<ReportingOptions>(out var options) == false)
+            if (settings.TryGet(out ReportingOptions options) == false)
             {
                 options = new ReportingOptions();
                 settings.Set<ReportingOptions>(options);
             }
-
-            options.ServiceControlMetricsAddress = serviceControlMetricsAddress;
-            options.EndpointInstanceIdOverride = instanceId;
+            return options;
         }
     }
 }

--- a/src/NServiceBus.Metrics.ServiceControl/BusConfigurationExtensions.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/BusConfigurationExtensions.cs
@@ -21,6 +21,17 @@
             options.EndpointInstanceIdOverride = instanceId;
         }
 
+        /// <summary>
+        /// Configures messages send to Service Control to be expired after <paramref name="timeToBeReceived"/>.
+        /// </summary>
+        /// <param name="busConfiguration">Bus configuration.</param>
+        /// <param name="timeToBeReceived">Time to be received.</param>
+        public static void SetServiceControlTTBR(this BusConfiguration busConfiguration, TimeSpan timeToBeReceived)
+        {
+            var options = GetReportingOptions(busConfiguration);
+            options.TimeToBeReceived = timeToBeReceived;
+        }
+
         static ReportingOptions GetReportingOptions(BusConfiguration busConfiguration)
         {
             var settings = busConfiguration.GetSettings();

--- a/src/NServiceBus.Metrics.ServiceControl/ReportingOptions.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingOptions.cs
@@ -1,10 +1,13 @@
 ﻿namespace NServiceBus.Metrics.ServiceControl
 {
+    using System;
+
     class ReportingOptions
     {
         internal string ServiceControlMetricsAddress;
         internal string EndpointInstanceIdOverride;
-
+        public TimeSpan TimeToBeReceived => TimeSpan.FromDays(7);
+        
         internal bool TryGetValidEndpointInstanceIdOverride(out string instanceId)
         {
             if (string.IsNullOrEmpty(EndpointInstanceIdOverride) == false)

--- a/src/NServiceBus.Metrics.ServiceControl/ReportingOptions.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingOptions.cs
@@ -6,7 +6,7 @@
     {
         internal string ServiceControlMetricsAddress;
         internal string EndpointInstanceIdOverride;
-        public TimeSpan TimeToBeReceived => TimeSpan.FromDays(7);
+        public TimeSpan TimeToBeReceived { get; set; } = TimeSpan.FromDays(7);
         
         internal bool TryGetValidEndpointInstanceIdOverride(out string instanceId)
         {

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlMonitoring.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlMonitoring.cs
@@ -255,13 +255,14 @@
                     {
                         Body = body,
                         MessageIntent = MessageIntentEnum.Send,
+                        TimeToBeReceived = timeToBeReceived,
                     };
                     try
                     {
                         dispatcher.Send(operation, new SendOptions(options.ServiceControlMetricsAddress)
                         {
                             TimeToBeReceived = timeToBeReceived,
-                            EnlistInReceiveTransaction = false
+                            EnlistInReceiveTransaction = false,
                         });
                     }
                     catch (Exception ex)

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlMonitoring.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlMonitoring.cs
@@ -260,7 +260,8 @@
                     {
                         dispatcher.Send(operation, new SendOptions(options.ServiceControlMetricsAddress)
                         {
-                            TimeToBeReceived = timeToBeReceived
+                            TimeToBeReceived = timeToBeReceived,
+                            EnlistInReceiveTransaction = false
                         });
                     }
                     catch (Exception ex)

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlMonitoring.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlMonitoring.cs
@@ -255,13 +255,14 @@
                     {
                         Body = body,
                         MessageIntent = MessageIntentEnum.Send,
+                        
+                        // TTBR is copied to the TransportMessage by the infrastructure before it hits. If ISendMessages is called manually, it needs to be passed in here
                         TimeToBeReceived = timeToBeReceived,
                     };
                     try
                     {
                         dispatcher.Send(operation, new SendOptions(options.ServiceControlMetricsAddress)
                         {
-                            TimeToBeReceived = timeToBeReceived,
                             EnlistInReceiveTransaction = false,
                         });
                     }

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/NServiceBusMetricReport.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/NServiceBusMetricReport.cs
@@ -15,6 +15,7 @@
             this.headers = headers;
             this.metricsContext = metricsContext;
             destination = options.ServiceControlMetricsAddress;
+            ttbr = options.TimeToBeReceived;
         }
 
         public void RunReport()
@@ -28,7 +29,10 @@
                 {
                     Body = body,
                     MessageIntent = MessageIntentEnum.Send
-                }, new SendOptions(destination));
+                }, new SendOptions(destination)
+                {
+                    TimeToBeReceived = ttbr
+                });
             }
             catch (Exception exception)
             {
@@ -40,6 +44,7 @@
         readonly string destination;
         readonly ISendMessages dispatcher;
         readonly Dictionary<string, string> headers;
+        readonly TimeSpan ttbr;
         static ILog log = LogManager.GetLogger<NServiceBusMetricReport>();
     }
 }

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/NServiceBusMetricReport.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/NServiceBusMetricReport.cs
@@ -31,7 +31,8 @@
                     MessageIntent = MessageIntentEnum.Send
                 }, new SendOptions(destination)
                 {
-                    TimeToBeReceived = ttbr
+                    TimeToBeReceived = ttbr,
+                    EnlistInReceiveTransaction = false,
                 });
             }
             catch (Exception exception)

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/NServiceBusMetricReport.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/NServiceBusMetricReport.cs
@@ -29,11 +29,12 @@
                 {
                     Body = body,
                     MessageIntent = MessageIntentEnum.Send,
+
+                    // TTBR is copied to the TransportMessage by the infrastructure before it hits. If ISendMessages is called manually, it needs to be passed in here
                     TimeToBeReceived = ttbr,
                 }, new SendOptions(destination)
                 {
                     EnlistInReceiveTransaction = false,
-                    TimeToBeReceived = ttbr
                 });
             }
             catch (Exception exception)

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/NServiceBusMetricReport.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/NServiceBusMetricReport.cs
@@ -28,11 +28,12 @@
                 dispatcher.Send(new TransportMessage(Guid.NewGuid().ToString(), headers)
                 {
                     Body = body,
-                    MessageIntent = MessageIntentEnum.Send
+                    MessageIntent = MessageIntentEnum.Send,
+                    TimeToBeReceived = ttbr,
                 }, new SendOptions(destination)
                 {
-                    TimeToBeReceived = ttbr,
                     EnlistInReceiveTransaction = false,
+                    TimeToBeReceived = ttbr
                 });
             }
             catch (Exception exception)


### PR DESCRIPTION
This PR introduced TTBR for reporting messages, ensuring that they will not flood messaging infrastructure when no receiver (SC.Monitoring) is available for a longer period of time.

Tests include two cases:
- reports with TTBR set are expired after TTBR is breached
- reports with TTBR set are received within TTBR window by the monitoring point

This is for 1.0 version of the plugin.