### PR TITLE
Introduce Time To Be Received for reporting messages to 2.0

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/Tests/When_reporting_to_ServiceControl_expires.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/Tests/When_reporting_to_ServiceControl_expires.cs
@@ -1,0 +1,105 @@
+﻿namespace NServiceBus.Metrics.ServiceControl.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using Pipeline;
+
+    public class When_reporting_to_ServiceControl_expires : NServiceBusAcceptanceTest
+    {
+        static string MonitoringSpyAddress => Conventions.EndpointNamingConvention(typeof(MonitoringMock));
+        static Guid HostId = Guid.NewGuid();
+        static readonly TimeSpan TTBR = TimeSpan.FromSeconds(10);
+
+        [Test]
+        public async Task Should_report_nothing_when_ttbr_breached()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(b => b.When(s=>s.SendLocal(new MyMessage())))
+                .Done(ctx => ctx.MessageProcessedBySender)
+                .Run();
+
+            await Task.Delay(TTBR + TTBR);
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<MonitoringMock>()
+                .Done(ctx => ctx.WasCalled)
+                .Run(TimeSpan.FromSeconds(10));
+
+            Assert.IsFalse(context.WasCalled);
+        }
+
+        [Test]
+        public async Task Should_report_when_ttbr_not_breached()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(b => b.When(s => s.SendLocal(new MyMessage())))
+                .WithEndpoint<MonitoringMock>()
+                .Done(ctx => ctx.WasCalled)
+                .Run();
+
+            Assert.True(context.WasCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MessageProcessedBySender { get; set; }
+            public bool WasCalled { get; set; }
+        }
+
+        class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UniquelyIdentifyRunningInstance().UsingCustomIdentifier(HostId);
+                    var metrics = c.EnableMetrics();
+                    metrics.SendMetricDataToServiceControl(MonitoringSpyAddress, TimeSpan.FromSeconds(1));
+                    metrics.SetServiceControlTTBR(TTBR);
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public async Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    await Task.Delay(100);
+                    Context.MessageProcessedBySender = true;
+                }
+            }
+        }
+
+        public class MonitoringMock : EndpointConfigurationBuilder
+        {
+            public MonitoringMock()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UseSerialization<NewtonsoftSerializer>();
+                    c.LimitMessageProcessingConcurrencyTo(1);
+                }).IncludeType<MetricReport>();
+            }
+
+            class MyRawMessageHandler : Behavior<IIncomingContext>
+            {
+                public Context Context { get; set; }
+
+                public override Task Invoke(IIncomingContext context, Func<Task> next)
+                {
+                    Context.WasCalled = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MyMessage : IMessage
+        { }
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/Tests/When_reporting_to_ServiceControl_expires.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/Tests/When_reporting_to_ServiceControl_expires.cs
@@ -27,7 +27,6 @@
 
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<MonitoringMock>()
-                .Done(ctx => ctx.WasCalled)
                 .Run(TimeSpan.FromSeconds(10));
 
             Assert.IsFalse(context.WasCalled);
@@ -60,7 +59,7 @@
                     c.UniquelyIdentifyRunningInstance().UsingCustomIdentifier(HostId);
                     var metrics = c.EnableMetrics();
                     metrics.SendMetricDataToServiceControl(MonitoringSpyAddress, TimeSpan.FromSeconds(1));
-                    metrics.SetServiceControlTTBR(TTBR);
+                    metrics.SetServiceControlMetricsMessageTTBR(TTBR);
                 });
             }
 
@@ -87,13 +86,14 @@
                 }).IncludeType<MetricReport>();
             }
 
-            class MyRawMessageHandler : Behavior<IIncomingContext>
+            public class MetricHandler : IHandleMessages<MetricReport>
             {
                 public Context Context { get; set; }
 
-                public override Task Invoke(IIncomingContext context, Func<Task> next)
+                public Task Handle(MetricReport message, IMessageHandlerContext context)
                 {
                     Context.WasCalled = true;
+                    
                     return Task.FromResult(0);
                 }
             }

--- a/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/Tests/When_reporting_to_ServiceControl_expires.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/Tests/When_reporting_to_ServiceControl_expires.cs
@@ -7,7 +7,6 @@
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
-    using Pipeline;
 
     public class When_reporting_to_ServiceControl_expires : NServiceBusAcceptanceTest
     {

--- a/src/NServiceBus.Metrics.ServiceControl.Tests/APIApprovals.Approve.approved.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/APIApprovals.Approve.approved.cs
@@ -3,6 +3,6 @@
     public class static MetricsOptionsExtensions
     {
         public static void SendMetricDataToServiceControl(this NServiceBus.MetricsOptions options, string serviceControlMetricsAddress, System.TimeSpan interval, string instanceId = null) { }
-        public static void SetServiceControlTTBR(this NServiceBus.MetricsOptions options, System.TimeSpan timeToBeReceived) { }
+        public static void SetServiceControlMetricsMessageTTBR(this NServiceBus.MetricsOptions options, System.TimeSpan timeToBeReceived) { }
     }
 }

--- a/src/NServiceBus.Metrics.ServiceControl.Tests/APIApprovals.Approve.approved.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/APIApprovals.Approve.approved.cs
@@ -3,5 +3,6 @@
     public class static MetricsOptionsExtensions
     {
         public static void SendMetricDataToServiceControl(this NServiceBus.MetricsOptions options, string serviceControlMetricsAddress, System.TimeSpan interval, string instanceId = null) { }
+        public static void SetServiceControlTTBR(this NServiceBus.MetricsOptions options, System.TimeSpan timeToBeReceived) { }
     }
 }

--- a/src/NServiceBus.Metrics.ServiceControl/MetricsOptionsExtensions.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/MetricsOptionsExtensions.cs
@@ -24,5 +24,17 @@
             reporting.ServiceControlReportingInterval = interval;
             reporting.EndpointInstanceIdOverride = instanceId;
         }
-    }
+
+        /// <summary>
+        /// Configures messages send to Service Control to be expired after <paramref name="timeToBeReceived"/>.
+        /// </summary>
+        /// <param name="options">The metrics options configuration object.</param>
+        /// <param name="timeToBeReceived">Time to be received.</param>
+        public static void SetServiceControlTTBR(this MetricsOptions options, TimeSpan timeToBeReceived)
+        {
+            var reporting = ReportingOptions.Get(options);
+
+            reporting.TimeToBeReceived = timeToBeReceived;
+        }
+}
 }

--- a/src/NServiceBus.Metrics.ServiceControl/MetricsOptionsExtensions.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/MetricsOptionsExtensions.cs
@@ -30,11 +30,11 @@
         /// </summary>
         /// <param name="options">The metrics options configuration object.</param>
         /// <param name="timeToBeReceived">Time to be received.</param>
-        public static void SetServiceControlTTBR(this MetricsOptions options, TimeSpan timeToBeReceived)
+        public static void SetServiceControlMetricsMessageTTBR(this MetricsOptions options, TimeSpan timeToBeReceived)
         {
             var reporting = ReportingOptions.Get(options);
 
             reporting.TimeToBeReceived = timeToBeReceived;
         }
-}
+    }
 }

--- a/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
@@ -16,7 +16,9 @@ using ServiceControl.Monitoring.Data;
 
 namespace NServiceBus.Metrics.ServiceControl
 {
+    using DeliveryConstraints;
     using MessageMutator;
+    using Performance.TimeToBeReceived;
 
     class ReportingFeature : Feature
     {
@@ -238,8 +240,11 @@ namespace NServiceBus.Metrics.ServiceControl
                 async Task Sender(byte[] body)
                 {
                     var message = new OutgoingMessage(Guid.NewGuid().ToString(), reporterHeaders, body);
-
-                    var operation = new TransportOperation(message, address);
+                    var constraints = new List<DeliveryConstraint>
+                    {
+                        new DiscardIfNotReceivedBefore(options.TimeToBeReceived)
+                    };
+                    var operation = new TransportOperation(message, address, DispatchConsistency.Default, constraints);
                     try
                     {
                         await dispatcher.Dispatch(new TransportOperations(operation), new TransportTransaction(), new ContextBag())

--- a/src/NServiceBus.Metrics.ServiceControl/ReportingOptions.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingOptions.cs
@@ -9,6 +9,7 @@
         internal string ServiceControlMetricsAddress;
         internal TimeSpan ServiceControlReportingInterval;
         internal string EndpointInstanceIdOverride;
+        public TimeSpan TimeToBeReceived { get; set; } = TimeSpan.FromDays(7);
 
         internal bool TryGetValidEndpointInstanceIdOverride(out string instanceId)
         {

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/NServiceBusMetricReport.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/NServiceBusMetricReport.cs
@@ -9,6 +9,9 @@ using NServiceBus.Transport;
 
 namespace NServiceBus.Metrics.ServiceControl.ServiceControlReporting
 {
+    using DeliveryConstraints;
+    using Performance.TimeToBeReceived;
+
     class NServiceBusMetricReport
     {
         public NServiceBusMetricReport(IDispatchMessages dispatcher, ReportingOptions options, Dictionary<string, string> headers, MetricsContext metricsContext)
@@ -18,6 +21,7 @@ namespace NServiceBus.Metrics.ServiceControl.ServiceControlReporting
             this.metricsContext = metricsContext;
 
             destination = new UnicastAddressTag(options.ServiceControlMetricsAddress);
+            timeToBeReceived = options.TimeToBeReceived;
         }
 
         public async Task RunReportAsync()
@@ -26,11 +30,16 @@ namespace NServiceBus.Metrics.ServiceControl.ServiceControlReporting
             var body = Encoding.UTF8.GetBytes(stringBody);
 
             var message = new OutgoingMessage(Guid.NewGuid().ToString(), headers, body);
-            var operation = new TransportOperation(message, destination);
+            var constraints = new List<DeliveryConstraint>
+            {
+                new DiscardIfNotReceivedBefore(timeToBeReceived)
+            };
+
+            var operation = new TransportOperation(message, destination, DispatchConsistency.Default, constraints);
 
             try
             {
-                await dispatcher.Dispatch(new TransportOperations(operation), transportTransaction, new ContextBag())
+                await dispatcher.Dispatch(new TransportOperations(operation), new TransportTransaction(), new ContextBag())
                     .ConfigureAwait(false);
             }
             catch (Exception exception)
@@ -39,11 +48,11 @@ namespace NServiceBus.Metrics.ServiceControl.ServiceControlReporting
             }
         }
 
-        UnicastAddressTag destination;
-        IDispatchMessages dispatcher;
-        Dictionary<string, string> headers;
+        readonly UnicastAddressTag destination;
+        readonly IDispatchMessages dispatcher;
+        readonly Dictionary<string, string> headers;
         readonly MetricsContext metricsContext;
-        TransportTransaction transportTransaction = new TransportTransaction();
+        readonly TimeSpan timeToBeReceived;
 
         static ILog log = LogManager.GetLogger<NServiceBusMetricReport>();
     }


### PR DESCRIPTION
This PR introduced TTBR for reporting messages, ensuring that they will not flood messaging infrastructure when no receiver (SC.Monitoring) is available for a longer period of time.

Tests include two cases:

-    reports with TTBR set are expired after TTBR is breached
-    reports with TTBR set are received within TTBR window by the monitoring point

This is for 2.0 version of the plugin.