### PR TITLE
Target net45 for 1.*

### DIFF
--- a/packaging/nuget/nservicebus.metrics.servicecontrol.nuspec
+++ b/packaging/nuget/nservicebus.metrics.servicecontrol.nuspec
@@ -17,6 +17,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\..\binaries\net452\NServiceBus.Metrics.ServiceControl.???" target="lib\net452" />
+    <file src="..\..\binaries\net45\NServiceBus.Metrics.ServiceControl.???" target="lib\net45" />
   </files>
 </package>

--- a/src/NServiceBus.Metrics.ServiceControl.Tests/NServiceBus.Metrics.ServiceControl.approved.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/NServiceBus.Metrics.ServiceControl.approved.cs
@@ -1,4 +1,4 @@
-﻿[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.5.2", FrameworkDisplayName=".NET Framework 4.5.2")]
+﻿[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.5", FrameworkDisplayName=".NET Framework 4.5")]
 
 namespace NServiceBus.Metrics.ServiceControl
 {

--- a/src/NServiceBus.Metrics.ServiceControl/NServiceBus.Metrics.ServiceControl.csproj
+++ b/src/NServiceBus.Metrics.ServiceControl/NServiceBus.Metrics.ServiceControl.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
     <OutputPath>..\..\binaries\</OutputPath>
     <DocumentationFile>..\..\binaries\net452\NServiceBus.Metrics.ServiceControl.xml</DocumentationFile>
     <LangVersion>7</LangVersion>

--- a/src/NServiceBus.Metrics.ServiceControl/NServiceBus.Metrics.ServiceControl.csproj
+++ b/src/NServiceBus.Metrics.ServiceControl/NServiceBus.Metrics.ServiceControl.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net45</TargetFramework>
     <OutputPath>..\..\binaries\</OutputPath>
-    <DocumentationFile>..\..\binaries\net452\NServiceBus.Metrics.ServiceControl.xml</DocumentationFile>
+    <DocumentationFile>..\..\binaries\net45\NServiceBus.Metrics.ServiceControl.xml</DocumentationFile>
     <LangVersion>7</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
@@ -18,19 +18,6 @@
     <PackageReference Include="ILRepack" Version="2.0.13" />
     <PackageReference Include="NServiceBus" Version="5.2.23" />
     <PackageReference Include="NuGetPackager" Version="0.6.5" />
-    <PackageReference Include="ServiceControl.Monitoring.Data" Version="1.0.2" />
+    <PackageReference Include="ServiceControl.Monitoring.Data" Version="2.0.0" />
   </ItemGroup>
-  <Target Name="MergeDependencies" AfterTargets="CopyFilesToOutputDirectory" Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <PropertyGroup>
-      <TempFolder>$(TargetDir)temp</TempFolder>
-    </PropertyGroup>
-    <MakeDir Directories="$(TempFolder)" />
-    <Exec Command="&quot;$(ILRepack)&quot; /out:&quot;$(TempFolder)\$(AssemblyName).dll&quot; &quot;$(TargetDir)$(AssemblyName).dll&quot; &quot;$(TargetDir)ServiceControl.Monitoring.Data.dll&quot; /targetplatform:v4 /internalize /lib:&quot;$(TargetDir).&quot;" />
-    <ItemGroup>
-      <TempFiles Include="$(TempFolder)\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(TempFiles)" DestinationFolder="$(OutputPath)" OverwriteReadOnlyFiles="true" />
-    <Delete Files="@(TempFiles)" />
-    <RemoveDir Directories="$(TempFolder)" />
-  </Target>
 </Project>


### PR DESCRIPTION
Solves #16

This PR changes the target framework of 1.* of this package from `net452` to `net45`. It's required as the core v5 targets mentioned `net45`. 

To do it, I needed to bump up `ServiceControl.Monitoring.Data` to version `2.0` that uses the source shipping approach. Version 1.0 of this package was targeting net452. This allowed me to remove `ILRepack` as well.

When reviewing please take a look at the nuget artifacts produced by build.
