### PR TITLE
[WIP] Add instance key

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/QueueLengthTracker.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/QueueLengthTracker.cs
@@ -4,7 +4,6 @@
     using System.Collections.Concurrent;
     using System.Threading.Tasks;
     using Features;
-    using Hosting;
     using Pipeline;
     using Routing;
 

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/QueueLengthTracker.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/QueueLengthTracker.cs
@@ -27,10 +27,11 @@
         {
             var queueLengthTracker = new QueueLengthTracker(metricsContext);
 
+            var logicalSourceKeyFactory = new LogicalSourceKeyFactory(featureContext.Settings.EndpointName());
+
             var pipeline = featureContext.Pipeline;
 
-            //Use HostId as a stable session ID
-            pipeline.Register(b => new DispatchQueueLengthBehavior(queueLengthTracker, new LogicalSourceKeyFactory(b.Build<HostInformation>().HostId.ToString())), nameof(DispatchQueueLengthBehavior));
+            pipeline.Register(b => new DispatchQueueLengthBehavior(queueLengthTracker, logicalSourceKeyFactory), nameof(DispatchQueueLengthBehavior));
 
             pipeline.Register(new IncomingQueueLengthBehavior(queueLengthTracker, featureContext.Settings.LocalAddress()), nameof(IncomingQueueLengthBehavior));
         }

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/QueueLengthTracker.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/QueueLengthTracker.cs
@@ -27,7 +27,7 @@
         {
             var queueLengthTracker = new QueueLengthTracker(metricsContext);
 
-            var logicalSourceKeyFactory = new LogicalSourceKeyFactory(featureContext.Settings.EndpointName());
+            var logicalSourceKeyFactory = new LogicalSourceKeyFactory(featureContext.Settings.EndpointName(), Guid.NewGuid().ToString());
 
             var pipeline = featureContext.Pipeline;
 
@@ -86,10 +86,12 @@
         class LogicalSourceKeyFactory
         {
             readonly string stableKey;
+            readonly string instanceKey;
 
-            public LogicalSourceKeyFactory(string stableKey)
+            public LogicalSourceKeyFactory(string stableKey, string instanceKey)
             {
                 this.stableKey = stableKey;
+                this.instanceKey = instanceKey;
             }
 
             public string BuildKey(AddressTag addressTag)
@@ -109,7 +111,7 @@
 
             string BuildKey(string destination)
             {
-                return $"{destination}-{stableKey}".ToLowerInvariant();
+                return $"{destination}-{stableKey};{instanceKey}".ToLowerInvariant();
             }
         }
 


### PR DESCRIPTION
Fixes #27 

The source for messages is now (EndpointName, Destination, InstanceKey). The InstanceKey is generated every time the endpoint starts. 

There will be a corresponding PR in the Monitoring server to track each instance independently under a link between (EndpointName, Destination) to the receiving endpoint. 