### PR TITLE
[SPIKE] Handle native timeouts

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl/MetricsReportBaseHeaderFactory.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/MetricsReportBaseHeaderFactory.cs
@@ -1,0 +1,36 @@
+﻿namespace NServiceBus.Metrics.ServiceControl
+{
+    using System.Collections.Generic;
+    using Hosting;
+    using Support;
+
+    class MetricsReportBaseHeaderFactory
+    {
+        public MetricsReportBaseHeaderFactory(string endpointName, ReportingOptions options)
+        {
+            this.endpointName = endpointName;
+            this.options = options;
+        }
+
+        internal Dictionary<string, string> BuildBaseHeaders(HostInformation hostInformation)
+        {
+            var headers = new Dictionary<string, string>
+            {
+                {Headers.OriginatingEndpoint, endpointName},
+                {Headers.OriginatingMachine, RuntimeEnvironment.MachineName},
+                {Headers.OriginatingHostId, hostInformation.HostId.ToString("N")},
+                {Headers.HostDisplayName, hostInformation.DisplayName},
+            };
+
+            if (options.TryGetValidEndpointInstanceIdOverride(out var instanceId))
+            {
+                headers.Add(MetricHeaders.MetricInstanceId, instanceId);
+            }
+
+            return headers;
+        }
+
+        readonly string endpointName;
+        readonly ReportingOptions options;
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl/QueueLength/BufferedQueueLengthProbe.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/QueueLength/BufferedQueueLengthProbe.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.Metrics.ServiceControl
+{
+    using global::ServiceControl.Monitoring.Data;
+
+    class BufferedQueueLengthProbe : IQueueLengthProbe
+    {
+        public BufferedQueueLengthProbe(RingBuffer buffer, TaggedLongValueWriterV1 writer)
+        {
+            this.buffer = buffer;
+            this.writer = writer;
+        }
+
+        public void Signal(string physicalAddress, long length)
+        {
+            var tag = writer.GetTagId(physicalAddress);
+            RingBufferExtensions.WriteTaggedValue(buffer, "QueueLength", length, tag);
+        }
+
+        readonly RingBuffer buffer;
+        readonly TaggedLongValueWriterV1 writer;
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl/QueueLength/IQueueLengthProbe.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/QueueLength/IQueueLengthProbe.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus.Metrics.ServiceControl
+{
+    /// <summary>
+    /// A metrics probe for queue length
+    /// </summary>
+    public interface IQueueLengthProbe
+    {
+        /// <summary>
+        /// Updates metrics with new queue length information
+        /// </summary>
+        /// <param name="physicalAddress">The physical address of the queue</param>
+        /// <param name="length">The current length of the queue</param>
+        void Signal(string physicalAddress, long length);
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl/QueueLength/LearningTransport/LearningTransportQueueLengthFinder.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/QueueLength/LearningTransport/LearningTransportQueueLengthFinder.cs
@@ -1,0 +1,84 @@
+﻿namespace NServiceBus.Metrics.ServiceControl
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Settings;
+    using Transport;
+    
+    class LearningTransportQueueLengthFinder 
+    {
+        public Task Warmup(ReadOnlySettings settings)
+        {
+            queueBindings = settings.Get<QueueBindings>();
+            transportFolder = GetTransportFolder(settings);
+            return Task.FromResult(0);
+        }
+
+        #region Transport Implementation Details
+
+        const string StorageLocationKey = "LearningTransport.StoragePath";
+
+        static string GetTransportFolder(ReadOnlySettings settings)
+        {
+            if (!settings.TryGet(StorageLocationKey, out string storagePath))
+            {
+                var solutionRoot = FindSolutionRoot();
+                storagePath = Path.Combine(solutionRoot, ".learningtransport");
+            }
+            return storagePath;
+        }
+
+        static string FindSolutionRoot()
+        {
+            var directory = AppDomain.CurrentDomain.BaseDirectory;
+
+            while (true)
+            {
+                if (Directory.EnumerateFiles(directory).Any(file => file.EndsWith(".sln")))
+                {
+                    return directory;
+                }
+
+                var parent = Directory.GetParent(directory);
+
+                if (parent == null)
+                {
+                    // throw for now. if we discover there is an edge then we can fix it in a patch.
+                    throw new Exception("Couldn't find the solution directory for the learning transport. If the endpoint is outside the solution folder structure, make sure to specify a storage directory using the 'EndpointConfiguration.UseTransport<LearningTransport>().StorageDirectory()' API.");
+                }
+
+                directory = parent.FullName;
+            }
+        }
+
+        #endregion
+
+        public Task UpdateQueueLength()
+        {
+            foreach (var queue in queueBindings.ReceivingAddresses)
+            {
+                var fullPath = Path.Combine(transportFolder, queue);
+                var dirInfo = new DirectoryInfo(fullPath);
+
+                if (dirInfo.Exists)
+                {
+                    var msgCount = dirInfo.EnumerateFiles().Count();
+                    probe.Signal(queue, msgCount);
+                }
+            }
+
+            return Task.FromResult(0);
+        }
+
+        QueueBindings queueBindings;
+        string transportFolder;
+        IQueueLengthProbe probe;
+
+        public LearningTransportQueueLengthFinder(IQueueLengthProbe probe)
+        {
+            this.probe = probe;
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl/QueueLength/LearningTransport/LearningTransportQueueLengthReporting.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/QueueLength/LearningTransport/LearningTransportQueueLengthReporting.cs
@@ -1,0 +1,66 @@
+﻿namespace NServiceBus.Metrics.ServiceControl
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Features;
+    using Settings;
+    using Transport;
+
+    class LearningTransportQueueLengthReporting : Feature
+    {
+        public LearningTransportQueueLengthReporting()
+        {
+            EnableByDefault();
+            DependsOn<ReportQueueLengthMetric>();
+            Prerequisite(ctx => ctx.Settings.Get<TransportDefinition>() is LearningTransport, "Learning Transport is not in use");
+        }
+
+        protected override void Setup(FeatureConfigurationContext context)
+        {
+            context.RegisterStartupTask(b =>
+            {
+                var probe = b.Build<IQueueLengthProbe>();
+                var queueLengthFinder = new LearningTransportQueueLengthFinder(probe);
+                return new QueueLengthCalculator(context.Settings, queueLengthFinder);
+            });
+        }
+
+        class QueueLengthCalculator : FeatureStartupTask
+        {
+            ReadOnlySettings settings;
+            LearningTransportQueueLengthFinder queueLengthFinder;
+
+            protected override Task OnStart(IMessageSession session)
+            {
+                task = Task.Run(async () =>
+                {
+                    await queueLengthFinder.Warmup(settings).ConfigureAwait(false);
+                    while (!cancellationTokenSource.IsCancellationRequested)
+                    {
+                        await queueLengthFinder.UpdateQueueLength().ConfigureAwait(false);
+                        await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
+                    }
+                });
+
+                return Task.FromResult(0);
+            }
+
+            protected override Task OnStop(IMessageSession session)
+            {
+                cancellationTokenSource.Cancel();
+
+                return task;
+            }
+
+            readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            Task task;
+
+            public QueueLengthCalculator(ReadOnlySettings settings, LearningTransportQueueLengthFinder queueLengthFinder)
+            {
+                this.settings = settings;
+                this.queueLengthFinder = queueLengthFinder;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl/QueueLength/LearningTransport/LearningTransportQueueLengthReporting.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/QueueLength/LearningTransport/LearningTransportQueueLengthReporting.cs
@@ -30,6 +30,7 @@
         {
             ReadOnlySettings settings;
             LearningTransportQueueLengthFinder queueLengthFinder;
+            TimeSpan delayBetweenChecks = TimeSpan.FromMilliseconds(500);
 
             protected override Task OnStart(IMessageSession session)
             {
@@ -39,7 +40,7 @@
                     while (!cancellationTokenSource.IsCancellationRequested)
                     {
                         await queueLengthFinder.UpdateQueueLength().ConfigureAwait(false);
-                        await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
+                        await Task.Delay(delayBetweenChecks).ConfigureAwait(false);
                     }
                 });
 

--- a/src/NServiceBus.Metrics.ServiceControl/QueueLength/ReportQueueLengthMetric.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/QueueLength/ReportQueueLengthMetric.cs
@@ -1,0 +1,70 @@
+﻿namespace NServiceBus.Metrics.ServiceControl
+{
+    using System.Threading.Tasks;
+    using Features;
+    using global::ServiceControl.Monitoring.Data;
+    using Hosting;
+
+    class ReportQueueLengthMetric : Feature
+    {
+        public ReportQueueLengthMetric()
+        {
+            EnableByDefault();
+            DependsOn<ReportingFeature>();
+        }
+
+        protected override void Setup(FeatureConfigurationContext context)
+        {
+            var buffer = new RingBuffer();
+            var writer = new TaggedLongValueWriterV1();
+
+            // NOTE: Exposes a hook for transports to write queue length to
+            context.Container.RegisterSingleton<IQueueLengthProbe>(new BufferedQueueLengthProbe(buffer, writer));
+
+            SetupServiceControlReporting(context, buffer, writer);
+        }
+
+        void SetupServiceControlReporting(FeatureConfigurationContext context, RingBuffer buffer, TaggedLongValueWriterV1 writer)
+        {
+            var metricsOptions = context.Settings.Get<MetricsOptions>();
+            var reportingOptions = ReportingOptions.Get(metricsOptions);
+            var baseHeaderFactory = new MetricsReportBaseHeaderFactory(context.Settings.EndpointName(), reportingOptions);
+
+            context.RegisterStartupTask(builder =>
+            {
+                var hostInformation = builder.Build<HostInformation>();
+
+                var headers = baseHeaderFactory.BuildBaseHeaders(hostInformation);
+
+                var rawDataReporterFactory = new RawDataReporterFactory(builder, reportingOptions, headers);
+
+                var queueLengthReporter = rawDataReporterFactory.CreateReporter("QueueLength", buffer, writer);
+
+                return new SendDataToServiceControl(queueLengthReporter);
+            });
+        }
+
+        class SendDataToServiceControl : FeatureStartupTask
+        {
+            public SendDataToServiceControl(RawDataReporter reporter)
+            {
+                this.reporter = reporter;
+            }
+
+            protected override Task OnStart(IMessageSession session)
+            {
+                reporter.Start();
+                return Task.FromResult(0);
+            }
+
+            protected override async Task OnStop(IMessageSession session)
+            {
+                await reporter.Stop().ConfigureAwait(false);
+
+                reporter.Dispose();
+            }
+
+            RawDataReporter reporter;
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl/RawDataReporterFactory.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/RawDataReporterFactory.cs
@@ -1,0 +1,65 @@
+﻿namespace NServiceBus.Metrics.ServiceControl
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using DeliveryConstraints;
+    using Extensibility;
+    using global::ServiceControl.Monitoring.Data;
+    using Logging;
+    using ObjectBuilder;
+    using Performance.TimeToBeReceived;
+    using Routing;
+    using Transport;
+
+    class RawDataReporterFactory
+    {
+        const string TaggedValueMetricContentType = "TaggedLongValueWriterOccurrence";
+
+        public RawDataReporterFactory(IBuilder builder, ReportingOptions options, Dictionary<string, string> headers)
+        {
+            this.builder = builder;
+            this.options = options;
+            this.headers = headers;
+        }
+
+        internal RawDataReporter CreateReporter(string metricType, RingBuffer buffer, TaggedLongValueWriterV1 writer)
+        {
+            var reporterHeaders = new Dictionary<string, string>(headers)
+            {
+                {Headers.ContentType, TaggedValueMetricContentType},
+                {MetricHeaders.MetricType, metricType}
+            };
+
+            var dispatcher = builder.Build<IDispatchMessages>();
+            var address = new UnicastAddressTag(options.ServiceControlMetricsAddress);
+
+            async Task Sender(byte[] body)
+            {
+                var message = new OutgoingMessage(Guid.NewGuid().ToString(), reporterHeaders, body);
+                var constraints = new List<DeliveryConstraint>
+                {
+                    new DiscardIfNotReceivedBefore(options.TimeToBeReceived)
+                };
+                var operation = new TransportOperation(message, address, DispatchConsistency.Default, constraints);
+                try
+                {
+                    await dispatcher.Dispatch(new TransportOperations(operation), new TransportTransaction(), new ContextBag())
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    log.Error($"Error while reporting raw data to {options.ServiceControlMetricsAddress}.", ex);
+                }
+            }
+
+            return new RawDataReporter(Sender, buffer, (entries, binaryWriter) => writer.Write(binaryWriter, entries), 2048, options.ServiceControlReportingInterval);
+        }
+
+        readonly IBuilder builder;
+        readonly ReportingOptions options;
+        readonly Dictionary<string, string> headers;
+
+        static readonly ILog log = LogManager.GetLogger<RawDataReporterFactory>();
+    }
+}


### PR DESCRIPTION
Get the endpoints to send their own queue length to ServiceControl Monitoring (which it can handle in https://github.com/Particular/ServiceControl.Monitoring/pull/114)

Exposes `IQueueLengthProbe` which is used by Learning Transport Native Queue Length reference implementation.

The idea is that each transport would have it's own implementation that will take a dependency on `IQueueLengthProbe` and update it as often as makes sense (for the transport). 

Each transport is responsible for what it considers to be a "Physical Address"