### PR TITLE
Native queue length support for core v5

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl.Tests/NServiceBus.Metrics.ServiceControl.approved.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/NServiceBus.Metrics.ServiceControl.approved.cs
@@ -5,4 +5,8 @@
         public static void SendMetricDataToServiceControl(this NServiceBus.BusConfiguration busConfiguration, string serviceControlMetricsAddress, string instanceId = null) { }
         public static void SetServiceControlMetricsMessageTTBR(this NServiceBus.BusConfiguration busConfiguration, System.TimeSpan timeToBeReceived) { }
     }
+    public interface IReportNativeQueueLength
+    {
+        void ReportQueueLength(string physicalQueueName, long queueLength);
+    }
 }

--- a/src/NServiceBus.Metrics.ServiceControl/Buffers.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/Buffers.cs
@@ -15,6 +15,7 @@
         public readonly Buffer ProcessingTime = new Buffer();
         public readonly Buffer CriticalTime = new Buffer();
         public readonly Buffer Retries = new Buffer();
+        public readonly Buffer QueueLength = new Buffer();
 
         static void Write(long value, string tag, Buffer buffer)
         {
@@ -50,6 +51,11 @@
         public void ReportRetry(string messageType)
         {
             Write(1, messageType, Retries);
+        }
+
+        public void ReportQueueLength(long value, string queueName)
+        {
+            Write(value, queueName, QueueLength);
         }
     }
 }

--- a/src/NServiceBus.Metrics.ServiceControl/IReportNativeQueueLength.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/IReportNativeQueueLength.cs
@@ -1,0 +1,28 @@
+﻿namespace NServiceBus.Metrics.ServiceControl
+{
+    /// <summary>
+    /// Reports native queue length to ServiceControl Monitoring
+    /// </summary>
+    public interface IReportNativeQueueLength
+    {
+        /// <summary>
+        /// Reports the length of a queue to be sent to ServiceControl Monitoring
+        /// </summary>
+        void ReportQueueLength(string physicalQueueName, long queueLength);
+    }
+
+    class QueueLengthBufferReporter : IReportNativeQueueLength
+    {
+        Buffers buffers;
+
+        public QueueLengthBufferReporter(Buffers buffers)
+        {
+            this.buffers = buffers;
+        }
+
+        public void ReportQueueLength(string physicalQueueName, long queueLength)
+        {
+            buffers.ReportQueueLength(queueLength, physicalQueueName);
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlMonitoring.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlMonitoring.cs
@@ -35,6 +35,7 @@
             var options = settings.Get<ReportingOptions>();
             var container = context.Container;
 
+            container.ConfigureComponent(() => new QueueLengthBufferReporter(buffers), DependencyLifecycle.SingleInstance);
             container.ConfigureComponent(() => options, DependencyLifecycle.SingleInstance);
             container.ConfigureComponent(builder =>
             {
@@ -231,6 +232,7 @@
                     BuildReporter("ProcessingTime", buffers.ProcessingTime),
                     BuildReporter("CriticalTime", buffers.CriticalTime),
                     BuildReporter("Retries", buffers.Retries),
+                    BuildReporter("QueueLength", buffers.QueueLength)
                 };
             }
 


### PR DESCRIPTION
Adds native queue length support for core v5.

Exposes `IReportNativeQueueLength` and includes an implementation in the container that will forward the data to ServiceControl Monitoring.