### PR TITLE
Alternative

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlMonitoring.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlMonitoring.cs
@@ -85,6 +85,16 @@
 
             RegisterStartupTask<ReportingStartupTask>();
             RegisterStartupTask<ServiceControlReporting>();
+
+
+            var queueLengthReport = new QueueLengthReport();
+            var queueLengthReporter = new NativeQueueLengthReporter(queueLengthReport);
+            queueLengthReporter.ReportQueueLength(settings.LocalAddress().ToString(), null);
+            container.ConfigureComponent<IReportNativeQueueLengths>(() => queueLengthReporter, DependencyLifecycle.SingleInstance);
+            container.ConfigureComponent<PeriodicallySendQueueDataToServiceControl>(DependencyLifecycle.SingleInstance)
+                .ConfigureProperty(task => task.HeaderValues, headers);
+
+            RegisterStartupTask<PeriodicallySendQueueDataToServiceControl>();
         }
 
         class ServiceControlMonitoringRegistrationBehavior : IBehavior<IncomingContext>

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/QueueLength/IReportNativeQueueLengths.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/QueueLength/IReportNativeQueueLengths.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.Metrics.ServiceControl
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Reports native queue lengths to a monitoring server
+    /// NOTE: Does not need to immediately report. Might cache values and report them later
+    /// </summary>
+    public interface IReportNativeQueueLengths
+    {
+        /// <summary>
+        /// The list of physcial queue instances that are being reported on
+        /// </summary>
+        IEnumerable<string> PhysicalQueues { get; }
+
+        /// <summary>
+        /// Report the length of a single physical queue
+        /// NOTE: If reported as null then only the linkage between endpoint instance and physical queue is reported
+        /// </summary>
+        void ReportQueueLength(string physicalQueue, long? queueLength);
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/QueueLength/NativeQueueLengthReporter.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/QueueLength/NativeQueueLengthReporter.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using NServiceBus.Metrics.ServiceControl;
+
+class NativeQueueLengthReporter : IReportNativeQueueLengths
+{
+    readonly QueueLengthReport report;
+
+    public NativeQueueLengthReporter(QueueLengthReport report)
+    {
+        this.report = report;
+    }
+
+    public void ReportQueueLength(string physicalQueueName, long? queueLength)
+    {
+        report.Queues[physicalQueueName] = queueLength;
+    }
+
+    public IEnumerable<string> PhysicalQueues => report.Queues.Keys;
+}

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/QueueLength/PeriodicallySendQueueDataToServiceControl.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/QueueLength/PeriodicallySendQueueDataToServiceControl.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.Features;
+using NServiceBus.Metrics.ServiceControl;
+using NServiceBus.Metrics.ServiceControl.ServiceControlReporting;
+using NServiceBus.Transports;
+
+class PeriodicallySendQueueDataToServiceControl : FeatureStartupTask
+{
+    public PeriodicallySendQueueDataToServiceControl(QueueLengthReport report, ISendMessages dispatcher, ReportingOptions options)
+    {
+        this.report = report;
+        this.dispatcher = dispatcher;
+        this.options = options;
+    }
+
+    protected override void OnStart()
+    {
+        HeaderValues.Add(Headers.EnclosedMessageTypes, "NServiceBus.Metrics.QueueReport");
+        HeaderValues.Add(Headers.ContentType, ContentTypes.Json);
+
+        var serviceControlReport = new SendQueueLengthReportToServiceControl(dispatcher, options, HeaderValues, report);
+
+        task = Task.Run(async () =>
+        {
+            while (cancellationTokenSource.IsCancellationRequested == false)
+            {
+                serviceControlReport.SendNow();
+                await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+            }
+        });
+    }
+
+    protected override void OnStop()
+    {
+        cancellationTokenSource.Cancel();
+        task.GetAwaiter().GetResult();
+    }
+
+    readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+    readonly QueueLengthReport report;
+    readonly ISendMessages dispatcher;
+    readonly ReportingOptions options;
+    public Dictionary<string, string> HeaderValues { get; set; }
+    Task task;
+}

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/QueueLength/QueueLengthReport.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/QueueLength/QueueLengthReport.cs
@@ -1,0 +1,7 @@
+﻿using System.Collections.Generic;
+
+class QueueLengthReport
+{
+    public long TimeStamp { get; set; }
+    public Dictionary<string, long?> Queues { get; } = new Dictionary<string, long?>();
+}

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/QueueLength/SendQueueLengthReportToServiceControl.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/QueueLength/SendQueueLengthReportToServiceControl.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NServiceBus;
+using NServiceBus.Logging;
+using NServiceBus.Metrics.ServiceControl;
+using NServiceBus.Metrics.ServiceControl.ServiceControlReporting;
+using NServiceBus.Transports;
+using NServiceBus.Unicast;
+
+class SendQueueLengthReportToServiceControl
+{
+    QueueLengthReport report;
+    ISendMessages dispatcher;
+    Dictionary<string, string> headers;
+    string destination;
+    TimeSpan ttbr;
+
+    public SendQueueLengthReportToServiceControl(ISendMessages dispatcher, ReportingOptions options, Dictionary<string, string> headers, QueueLengthReport report)
+    {
+        this.dispatcher = dispatcher;
+        this.headers = headers;
+        destination = options.ServiceControlMetricsAddress;
+        ttbr = options.TimeToBeReceived;
+        this.report = report;
+    }
+
+    public void SendNow()
+    {
+        report.TimeStamp = DateTime.UtcNow.Ticks;
+        var stringBody = SimpleJson.SerializeObject(report);
+        var body = Encoding.UTF8.GetBytes(stringBody);
+
+        try
+        {
+            dispatcher.Send(new TransportMessage(Guid.NewGuid().ToString(), headers)
+            {
+                Body = body,
+                MessageIntent = MessageIntentEnum.Send,
+
+                // TTBR is copied to the TransportMessage by the infrastructure before it hits. If ISendMessages is called manually, it needs to be passed in here
+                TimeToBeReceived = ttbr,
+            }, new SendOptions(destination)
+            {
+                EnlistInReceiveTransaction = false,
+            });
+        }
+        catch (Exception exception)
+        {
+            log.Error($"Error while sending metric data to {destination}.", exception);
+        }
+    }
+
+    static ILog log = LogManager.GetLogger<SendQueueLengthReportToServiceControl>();
+}


### PR DESCRIPTION
Implemented approach after a chat with @tmasternak .

Basically the NSB.Metrics.SC plugin will need to periodically report EndpointInstance->PhysicalQueue mappings periodically anyway. We can fit the Native Queue Length infrastructure into that. Native Queue Length will take an instance of `IReportNativeQueueLengths`, it will get the list of queues that it cares about from there, and it will periodically update the queue length data. 

Tomasz is this what you had in mind? 
