### PR TITLE
EndpointMetadata property name changed to expected value

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/Tests/EndpointMetadataReport.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/Tests/EndpointMetadataReport.cs
@@ -3,6 +3,6 @@
     public class EndpointMetadataReport : IMessage
     {
         public string LocalAddress { get; set; }
-        public int Version { get; set; }
+        public int PluginVersion { get; set; }
     }
 }

--- a/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/Tests/When_reporting_to_ServiceControl.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/Tests/When_reporting_to_ServiceControl.cs
@@ -25,7 +25,7 @@
                 .ConfigureAwait(false);
 
             Assert.IsNotNull(context.Report);
-            Assert.AreEqual(3, context.Report.Version);
+            Assert.AreEqual(3, context.Report.PluginVersion);
             Assert.IsNotEmpty(context.Report.LocalAddress);
 
             Assert.AreEqual(HostId.ToString("N"), context.Headers[Headers.OriginatingHostId]);

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/EndpointMetadata.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/EndpointMetadata.cs
@@ -13,7 +13,7 @@
         {
             return SimpleJson.SerializeObject(new
             {
-                Version = 3,
+                PluginVersion = 3,
                 LocalAddress = localAddress
             });
         }


### PR DESCRIPTION
## Overview
This fix changes `EndpointMetadata` property name to be the one expected by monitoring instance.