### PR TITLE
support 21 update dev tooling

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/NServiceBus.Metrics.ServiceControl.AcceptanceTests.csproj
+++ b/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/NServiceBus.Metrics.ServiceControl.AcceptanceTests.csproj
@@ -9,10 +9,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="6.4.4" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Metrics.ServiceControl.Tests/NServiceBus.Metrics.ServiceControl.Tests.csproj
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/NServiceBus.Metrics.ServiceControl.Tests.csproj
@@ -11,9 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Particular.Approvals" Version="0.1.0" />
     <PackageReference Include="PublicApiGenerator" Version="7.0.1" />
   </ItemGroup>

--- a/src/NServiceBus.Metrics.ServiceControl.Tests/NServiceBus.Metrics.ServiceControl.Tests.csproj
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/NServiceBus.Metrics.ServiceControl.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Particular.Approvals" Version="0.1.0" />
+    <PackageReference Include="Particular.Approvals" Version="0.2.0" />
     <PackageReference Include="PublicApiGenerator" Version="7.0.1" />
   </ItemGroup>
 

--- a/src/NServiceBus.Metrics.ServiceControl.Tests/NServiceBus.Metrics.ServiceControl.Tests.csproj
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/NServiceBus.Metrics.ServiceControl.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Particular.Approvals" Version="0.2.0" />
-    <PackageReference Include="PublicApiGenerator" Version="7.0.1" />
+    <PackageReference Include="PublicApiGenerator" Version="8.1.0" />
   </ItemGroup>
 
   </Project>

--- a/src/NServiceBus.Metrics.ServiceControl/NServiceBus.Metrics.ServiceControl.csproj
+++ b/src/NServiceBus.Metrics.ServiceControl/NServiceBus.Metrics.ServiceControl.csproj
@@ -10,13 +10,8 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="[6.4.4, 7.0.0)" />
     <PackageReference Include="NServiceBus.Metrics" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="0.2.1" PrivateAssets="All" />
     <PackageReference Include="ServiceControl.Monitoring.Data" Version="2.1.1" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="SourceLink.Create.GitHub" Version="2.6.0" PrivateAssets="All" />
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.6.0" />
   </ItemGroup>
 
   </Project>


### PR DESCRIPTION
This updates development tooling on the `support-2.1` branch.
Note: This should not be squashed.