### PR TITLE
Hotfix 3.0.3

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/Tests/When_stopping_endpoint_with_reporting_enabled.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/Tests/When_stopping_endpoint_with_reporting_enabled.cs
@@ -1,0 +1,65 @@
+namespace NServiceBus.Metrics.AcceptanceTests
+{
+    using System;
+    using System.Diagnostics;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_stopping_endpoint_with_reporting_enabled : NServiceBusAcceptanceTest
+    {
+        static string MonitoringSpyAddress => Conventions.EndpointNamingConvention(typeof(MonitoringSpy));
+        static TimeSpan SendInterval = TimeSpan.FromSeconds(30);
+
+        [Test]
+        public async Task Should_not_delay_endpoint_stop()
+        {
+            var stopWatch = Stopwatch.StartNew();
+            
+            await Scenario.Define<ScenarioContext>()
+                .WithEndpoint<Sender>()
+                .WithEndpoint<MonitoringSpy>()
+                .Done(c => c.EndpointsStarted)
+                .Run()
+                .ConfigureAwait(false);
+            
+            stopWatch.Stop();
+            
+            Assert.That(stopWatch.Elapsed, Is.LessThan(SendInterval));
+        }
+        
+        class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.EnableMetrics().SendMetricDataToServiceControl(MonitoringSpyAddress, SendInterval);
+                });
+            }
+        }
+
+        class MonitoringSpy : EndpointConfigurationBuilder
+        {
+            public MonitoringSpy()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UseSerialization<NewtonsoftSerializer>();
+                    c.LimitMessageProcessingConcurrencyTo(1);
+                }).IncludeType<EndpointMetadataReport>();
+            }
+
+            public class MetricHandler : IHandleMessages<EndpointMetadataReport>
+            {
+                public Task Handle(EndpointMetadataReport message, IMessageHandlerContext context)
+                {
+                    return Task.FromResult(0);
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
@@ -186,7 +186,16 @@ namespace NServiceBus.Metrics.ServiceControl
                     while (cancellationTokenSource.IsCancellationRequested == false)
                     {
                         await serviceControlReport.RunReportAsync().ConfigureAwait(false);
-                        await Task.Delay(options.ServiceControlReportingInterval).ConfigureAwait(false);
+
+                        try
+                        {
+                            await Task.Delay(options.ServiceControlReportingInterval, cancellationTokenSource.Token).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            // shutdown
+                            return;
+                        }
                     }
                 });
 


### PR DESCRIPTION
Raised based on https://discuss.particular.net/t/shutdown-of-services-takes-a-long-time-with-servicecontrol-metrics-plugin-enabled/

## Who's affected

All customers using `SendMetricDataToServiceControl`

## Symptoms

When stopping an endpoint, the operation can be delayed until `ServiceControlReportingInterval` is reached.