### PR TITLE
Make dependency on MetricsFeature explicit

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
@@ -25,6 +25,7 @@ namespace NServiceBus.Metrics.ServiceControl
         public ReportingFeature()
         {
             EnableByDefault();
+            DependsOn("MetricsFeature");
             Prerequisite(ctx =>
             {
                 var options = ctx.Settings.GetOrDefault<MetricsOptions>();


### PR DESCRIPTION
Not able to use `DependsOn<T>()` because `MetricsFeature` [is internal](https://github.com/Particular/NServiceBus.Metrics/blob/master/src/NServiceBus.Metrics/MetricsFeature.cs#L7).