### PR TITLE
Fix for plugin not sending metric data to ServiceControl (3.0)

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl/MetricsOptionsExtensions.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/MetricsOptionsExtensions.cs
@@ -23,6 +23,8 @@
             reporting.ServiceControlMetricsAddress = serviceControlMetricsAddress;
             reporting.ServiceControlReportingInterval = interval;
             reporting.EndpointInstanceIdOverride = instanceId;
+
+            options.RegisterObservers(context => reporting.CreateReporters());
         }
 
         /// <summary>

--- a/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
@@ -232,15 +232,18 @@ namespace NServiceBus.Metrics.ServiceControl
 
             protected override Task OnStart(IMessageSession session)
             {
-                foreach (var metric in metrics)
+                options.OnCreateReporters(() =>
                 {
-                    reporters.Add(CreateReporter(metric.Key, metric.Value.Item1, metric.Value.Item2));
-                }
+                    foreach (var metric in metrics)
+                    {
+                        reporters.Add(CreateReporter(metric.Key, metric.Value.Item1, metric.Value.Item2));
+                    }
 
-                foreach (var reporter in reporters)
-                {
-                    reporter.Start();
-                }
+                    foreach (var reporter in reporters)
+                    {
+                        reporter.Start();
+                    }
+                });                
 
                 return Task.FromResult(0);
             }

--- a/src/NServiceBus.Metrics.ServiceControl/ReportingOptions.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingOptions.cs
@@ -10,6 +10,8 @@
         internal TimeSpan ServiceControlReportingInterval;
         internal string EndpointInstanceIdOverride;
         public TimeSpan TimeToBeReceived { get; set; } = TimeSpan.FromDays(7);
+        Action createMetricReporters;
+        bool createReportersCalled;
 
         internal bool TryGetValidEndpointInstanceIdOverride(out string instanceId)
         {
@@ -24,5 +26,32 @@
         }
 
         public static ReportingOptions Get(MetricsOptions options) => reporting.GetOrAdd(options, metricsOptions => new ReportingOptions());
+
+        internal void CreateReporters()
+        {
+            if(createReportersCalled)
+            {
+                throw new Exception("CreateReporters has already been called, and can only be called once.");
+            }
+
+            createReportersCalled = true;
+            if(createMetricReporters != null)
+            {
+                createMetricReporters();
+                createMetricReporters = null;
+            }
+        }
+
+        internal void OnCreateReporters(Action createMetricReporters)
+        {
+            if(createReportersCalled)
+            {
+                createMetricReporters();
+            }
+            else
+            {
+                this.createMetricReporters = createMetricReporters;
+            }
+        }
     }
 }


### PR DESCRIPTION
(cherry picked from commit 677d6a270a2dce7e68927458e70c923331fe796f)

## Symptoms

* Endpoint metrics data is not delivered to ServiceControl, and cannot be viewed in ServicePulse
* Log warnings stating `Failed to buffer metrics data for ${metricType} after ${attempts} attempts.`

## Who's affected

Some customers experience the symptoms listed above due to a non-deterministic execution order due to an unknown root cause. It is possible for some endpoints to be affected while others are not.

## More information

See https://github.com/Particular/NServiceBus.Metrics.ServiceControl/issues/67