### PR TITLE
Add additional logging for RingBuffer usage

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
@@ -271,6 +271,11 @@ namespace NServiceBus.Metrics.ServiceControl
                     {
                         await dispatcher.Dispatch(new TransportOperations(operation), new TransportTransaction(), new ContextBag())
                             .ConfigureAwait(false);
+
+                        if (log.IsDebugEnabled)
+                        {
+                            log.Debug($"Sent {body.Length} bytes for {metricType} metric.");
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/src/NServiceBus.Metrics.ServiceControl/RingBufferExtensions.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/RingBufferExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using NServiceBus.Logging;
 using ServiceControl.Monitoring.Data;
 
@@ -17,9 +18,10 @@ class RingBufferExtensions
 
             if (attempts >= MaxExpectedWriteAttempts)
             {
-                log.Warn($"Failed to buffer metrics data for ${metricType} after ${attempts} attempts.");
+                log.Warn($"Thread {Thread.CurrentThread.ManagedThreadId} failed to buffer metrics data for '{metricType}' after {attempts} attempts.");
                 attempts = 0;
             }
+
         }
     }
 


### PR DESCRIPTION
This might help us to get some additional insights about support cases where we see the `Failed to buffer metrics data for {metricType} after 10 attempts."` log warning by logging a few more details:
* Logging the thread id might give us a better understanding how many threads are failing to write to the buffer at once and how often a specific thread fails to write to the buffer as we currently do not log successful writes to the buffer (that might flood our logs too quickly to be useful).
* Logging when metrics data has been sent to the metrics queue. This can give us additional insights whether only one metric reporting loop is failing, whether it's completely missing or just slow.