### PR TITLE
Report metrics when order of FeatureStartupTasks changes

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl/MetricsOptionsExtensions.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/MetricsOptionsExtensions.cs
@@ -23,8 +23,6 @@
             reporting.ServiceControlMetricsAddress = serviceControlMetricsAddress;
             reporting.ServiceControlReportingInterval = interval;
             reporting.EndpointInstanceIdOverride = instanceId;
-
-            options.RegisterObservers(context => reporting.CreateReporters());
         }
 
         /// <summary>

--- a/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
@@ -74,6 +74,7 @@ namespace NServiceBus.Metrics.ServiceControl
                 metrics[name] = Tuple.Create(buffer, writer);
             }
 
+            var reportingOptions = ReportingOptions.Get(options);
             options.RegisterObservers(probeContext =>
             {
                 foreach (var durationProbe in probeContext.Durations)
@@ -92,13 +93,13 @@ namespace NServiceBus.Metrics.ServiceControl
                         RegisterSignal(signalProbe);
                     }
                 }
+
+                reportingOptions.CreateReporters();
             });
 
             var queueLengthMetric = SetupQueueLengthReporting(context);
 
             metrics.Add("QueueLength", queueLengthMetric);
-
-            var reportingOptions = ReportingOptions.Get(options);
 
             SetUpServiceControlReporting(context, reportingOptions, endpointName, metrics);
         }


### PR DESCRIPTION
It seems #67 wasn't completely fixed by the changes mentioned on the issue. There is still a race condition based on the order of two different `FeatureStartupTask`s.

In the happy case, the following order ensures that the metrics reporting is created correctly:
1. `SetupRegisteredObservers` calls `MetricsOptions.SetupObserver` that will invoke the two registered callbacks from the `NServiceBus.Metrics.ServiceControl` plugin:
    1. `CreateReporters` (will set `ReportingOptions.reportsCalled` to true)
    1. `RegisterObserver` (adds the critical and processing time metrics to the `metrics` collection)
1. `ServiceControlRawDataReporting` registers the reporter factories on `ReportingOptions.OnCreateReporters`. Since `ReportingOptions.reportsCalled` is already true, the reports in the `metrics` collection are created and started.

However, if the order is reverse, it will invoke the raw data reporting callback too early:
1. `ServiceControlRawDataReporting` registers the reporter factories on `ReportingOptions.OnCreateReporters`. Since `ReportingOptions.reportsCalled` is false, the callback is not invoked but stored for later.
1. `SetupRegisteredObservers` calls `MetricsOptions.SetupObserver` that will invoke the two registered callbacks from the `NServiceBus.Metrics.ServiceControl` plugin:
    1. `CreateReporters` will invoke the reporter registered in step 1. However, the `metrics` collection does not contain the critical time and processing time metrics yet.
    1. `RegisterObserver` (adds the critical and processing time metrics to the `metrics` collection)

The fix merges the two callbacks into a single callback that calls `CreateReporters` after registering the observers to ensure the metrics collection is always properly initialized before creating the reporters, regardless of FST invocation order
