### PR TITLE
Ensure order of feature startup task is guaranteed

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl/MetricsOptionsExtensions.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/MetricsOptionsExtensions.cs
@@ -23,8 +23,6 @@
             reporting.ServiceControlMetricsAddress = serviceControlMetricsAddress;
             reporting.ServiceControlReportingInterval = interval;
             reporting.EndpointInstanceIdOverride = instanceId;
-
-            options.RegisterObservers(context => reporting.CreateReporters());
         }
 
         /// <summary>

--- a/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
@@ -232,18 +232,15 @@ namespace NServiceBus.Metrics.ServiceControl
 
             protected override Task OnStart(IMessageSession session)
             {
-                options.OnCreateReporters(() =>
+                foreach (var metric in metrics)
                 {
-                    foreach (var metric in metrics)
-                    {
-                        reporters.Add(CreateReporter(metric.Key, metric.Value.Item1, metric.Value.Item2));
-                    }
+                    reporters.Add(CreateReporter(metric.Key, metric.Value.Item1, metric.Value.Item2));
+                }
 
-                    foreach (var reporter in reporters)
-                    {
-                        reporter.Start();
-                    }
-                });                
+                foreach (var reporter in reporters)
+                {
+                    reporter.Start();
+                }
 
                 return Task.FromResult(0);
             }

--- a/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
@@ -25,6 +25,7 @@ namespace NServiceBus.Metrics.ServiceControl
         public ReportingFeature()
         {
             EnableByDefault();
+            DependsOn("MetricsFeature");
             Prerequisite(ctx =>
             {
                 var options = ctx.Settings.GetOrDefault<MetricsOptions>();

--- a/src/NServiceBus.Metrics.ServiceControl/ReportingOptions.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingOptions.cs
@@ -10,8 +10,6 @@
         internal TimeSpan ServiceControlReportingInterval;
         internal string EndpointInstanceIdOverride;
         public TimeSpan TimeToBeReceived { get; set; } = TimeSpan.FromDays(7);
-        Action createMetricReporters;
-        bool createReportersCalled;
 
         internal bool TryGetValidEndpointInstanceIdOverride(out string instanceId)
         {
@@ -26,32 +24,5 @@
         }
 
         public static ReportingOptions Get(MetricsOptions options) => reporting.GetOrAdd(options, metricsOptions => new ReportingOptions());
-
-        internal void CreateReporters()
-        {
-            if (createReportersCalled)
-            {
-                throw new Exception("CreateReporters has already been called, and can only be called once.");
-            }
-
-            createReportersCalled = true;
-            if (createMetricReporters != null)
-            {
-                createMetricReporters();
-                createMetricReporters = null;
-            }
-        }
-
-        internal void OnCreateReporters(Action createMetricReporters)
-        {
-            if (createReportersCalled)
-            {
-                createMetricReporters();
-            }
-            else
-            {
-                this.createMetricReporters = createMetricReporters;
-            }
-        }
     }
 }


### PR DESCRIPTION
Alternative to #141 

There is still a race condition based on the order of two different `FeatureStartupTask`s.

In the happy case, the following order ensures that the metrics reporting is created correctly:
1. `SetupRegisteredObservers` calls `MetricsOptions.SetupObserver` that will invoke the two registered callbacks from the `NServiceBus.Metrics.ServiceControl` plugin:
    1. `CreateReporters` (will set `ReportingOptions.reportsCalled` to true)
    1. `RegisterObserver` (adds the critical and processing time metrics to the `metrics` collection)
1. `ServiceControlRawDataReporting` registers the reporter factories on `ReportingOptions.OnCreateReporters`. Since `ReportingOptions.reportsCalled` is already true, the reports in the `metrics` collection are created and started.

However, if the order is reverse, it will invoke the raw data reporting callback too early:
1. `ServiceControlRawDataReporting` registers the reporter factories on `ReportingOptions.OnCreateReporters`. Since `ReportingOptions.reportsCalled` is false, the callback is not invoked but stored for later.
1. `SetupRegisteredObservers` calls `MetricsOptions.SetupObserver` that will invoke the two registered callbacks from the `NServiceBus.Metrics.ServiceControl` plugin:
    1. `CreateReporters` will invoke the reporter registered in step 1. However, the `metrics` collection does not contain the critical time and processing time metrics yet.
    1. `RegisterObserver` (adds the critical and processing time metrics to the `metrics` collection)

Core 7.2.4 and higher [has fixed the startup order of feature startup tasks](https://github.com/Particular/NServiceBus/pull/5621) when they declare a dependency order