### PR TITLE
Change dependency to public type

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/NServiceBus.Metrics.ServiceControl.AcceptanceTests.csproj
+++ b/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/NServiceBus.Metrics.ServiceControl.AcceptanceTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.631" />
-    <PackageReference Include="NServiceBus.Metrics" Version="4.0.0-alpha.103" />
+    <PackageReference Include="NServiceBus.Metrics" Version="4.0.0-alpha.117" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.2.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />

--- a/src/NServiceBus.Metrics.ServiceControl/NServiceBus.Metrics.ServiceControl.csproj
+++ b/src/NServiceBus.Metrics.ServiceControl/NServiceBus.Metrics.ServiceControl.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.630, 9.0.0)" />
-    <PackageReference Include="NServiceBus.Metrics" Version="[4.0.0-alpha.103, 5.0.0)" />
+    <PackageReference Include="NServiceBus.Metrics" Version="[4.0.0-alpha.117, 5.0.0)" />
     <PackageReference Include="Particular.CodeRules" Version="0.7.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
     <PackageReference Include="ServiceControl.Monitoring.Data" Version="2.1.1" PrivateAssets="All" />

--- a/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
@@ -25,7 +25,7 @@ namespace NServiceBus.Metrics.ServiceControl
         public ReportingFeature()
         {
             EnableByDefault();
-            DependsOn("MetricsFeature");
+            DependsOn<MetricsFeature>();
             Prerequisite(ctx =>
             {
                 var options = ctx.Settings.GetOrDefault<MetricsOptions>();


### PR DESCRIPTION
With the latest alpha release of NServiceBus.Metrics, the `MetricsFeature` type is public so we can depend on the type in a statically typed way instead of using a magic string.