### PR TITLE
Mention correct queue name in error log

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/NServiceBusMetadataReport.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/NServiceBusMetadataReport.cs
@@ -42,7 +42,7 @@
             }
             catch (Exception ex) when (!ex.IsCausedBy(cancellationToken))
             {
-                log.Error($"Error while sending metric data to {destination}.", ex);
+                log.Error($"Error while sending metric data to {destination.Destination}.", ex);
             }
         }
 


### PR DESCRIPTION
Currently, the error message shows `NServiceBus.Metrics.ServiceControl.ServiceControlReporting.NServiceBusMetadataReport] Error while sending metric data to NServiceBus.Routing.UnicastAddressTag. ` which is not helpful as `UnicastAddressTag` doesn't implement a useful `ToString`.