### PR TITLE
Update receive addresses usage

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/NServiceBus.Metrics.ServiceControl.AcceptanceTests.csproj
+++ b/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/NServiceBus.Metrics.ServiceControl.AcceptanceTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.1897" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.1900" />
     <PackageReference Include="NServiceBus.Metrics" Version="4.0.0-alpha.152" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-alpha.155 " />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/src/NServiceBus.Metrics.ServiceControl.Tests/NServiceBus.Metrics.ServiceControl.Tests.csproj
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/NServiceBus.Metrics.ServiceControl.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1897" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1900" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Metrics.ServiceControl/IReportNativeQueueLength.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/IReportNativeQueueLength.cs
@@ -25,11 +25,14 @@
         TaggedLongValueWriterV1 writer;
         string[] monitoredQueues;
 
-        public QueueLengthBufferReporter(RingBuffer buffer, TaggedLongValueWriterV1 writer, params string[] monitoredQueues)
+        public QueueLengthBufferReporter(RingBuffer buffer, TaggedLongValueWriterV1 writer, ReceiveAddresses receiveAddresses)
         {
             this.buffer = buffer;
             this.writer = writer;
-            this.monitoredQueues = monitoredQueues;
+            monitoredQueues = new[]
+            {
+                receiveAddresses.MainReceiveAddress
+            };
         }
 
         public void ReportQueueLength(string physicalQueueName, long queueLength)

--- a/src/NServiceBus.Metrics.ServiceControl/IReportNativeQueueLength.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/IReportNativeQueueLength.cs
@@ -25,14 +25,11 @@
         TaggedLongValueWriterV1 writer;
         string[] monitoredQueues;
 
-        public QueueLengthBufferReporter(RingBuffer buffer, TaggedLongValueWriterV1 writer, ReceiveAddresses receiveAddresses)
+        public QueueLengthBufferReporter(RingBuffer buffer, TaggedLongValueWriterV1 writer, params string[] monitoredQueues)
         {
             this.buffer = buffer;
             this.writer = writer;
-            monitoredQueues = new[]
-            {
-                receiveAddresses.MainReceiveAddress
-            };
+            this.monitoredQueues = monitoredQueues;
         }
 
         public void ReportQueueLength(string physicalQueueName, long queueLength)

--- a/src/NServiceBus.Metrics.ServiceControl/NServiceBus.Metrics.ServiceControl.csproj
+++ b/src/NServiceBus.Metrics.ServiceControl/NServiceBus.Metrics.ServiceControl.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.1897, 9.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.1900, 9.0.0)" />
     <PackageReference Include="NServiceBus.Metrics" Version="[4.0.0-alpha.152, 5.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="1.3.0" PrivateAssets="All" />
     <PackageReference Include="ServiceControl.Monitoring.Data" Version="2.2.0-alpha.107" PrivateAssets="All" />

--- a/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
@@ -193,12 +193,12 @@
                             catch (Exception ex) when (ex.IsCausedBy(cancellationTokenSource.Token))
                             {
                                 // private token, reporting is being stopped, log the exception in case the stack trace is ever needed for debugging
-                                log.Debug("Operation canceled while stopping ServiceControl metadata reporting.", ex);
+                                Log.Debug("Operation canceled while stopping ServiceControl metadata reporting.", ex);
                                 break;
                             }
                             catch (Exception ex)
                             {
-                                log.Error("Failed to report metrics to ServiceControl.", ex);
+                                Log.Error("Failed to report metrics to ServiceControl.", ex);
                             }
                         }
                     },
@@ -220,7 +220,7 @@
             readonly Dictionary<string, string> headers;
             Task task;
 
-            static readonly ILog log = LogManager.GetLogger<ServiceControlMetadataReporting>();
+            static readonly ILog Log = LogManager.GetLogger<ServiceControlMetadataReporting>();
         }
 
         class ServiceControlRawDataReporting : FeatureStartupTask
@@ -279,14 +279,14 @@
                         await dispatcher.Dispatch(new TransportOperations(operation), new TransportTransaction(), cancellationToken)
                             .ConfigureAwait(false);
 
-                        if (log.IsDebugEnabled)
+                        if (Log.IsDebugEnabled)
                         {
-                            log.Debug($"Sent {body.Length} bytes for {metricType} metric.");
+                            Log.Debug($"Sent {body.Length} bytes for {metricType} metric.");
                         }
                     }
                     catch (Exception ex) when (!ex.IsCausedBy(cancellationToken))
                     {
-                        log.Error($"Error while reporting raw data to {options.ServiceControlMetricsAddress}.", ex);
+                        Log.Error($"Error while reporting raw data to {options.ServiceControlMetricsAddress}.", ex);
                     }
                 }
 
@@ -309,7 +309,7 @@
             readonly Dictionary<string, Tuple<RingBuffer, TaggedLongValueWriterV1>> metrics;
             readonly List<RawDataReporter> reporters;
 
-            static readonly ILog log = LogManager.GetLogger<ServiceControlRawDataReporting>();
+            static readonly ILog Log = LogManager.GetLogger<ServiceControlRawDataReporting>();
         }
 
         class MetricsIdAttachingMutator : IMutateOutgoingMessages

--- a/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
@@ -107,7 +107,10 @@
             var queueLengthWriter = new TaggedLongValueWriterV1();
 
             context.Services.AddSingleton<IReportNativeQueueLength>(sp =>
-                new QueueLengthBufferReporter(queueLengthBuffer, queueLengthWriter, sp.GetRequiredService<ReceiveAddresses>()));
+                new QueueLengthBufferReporter(
+                    queueLengthBuffer,
+                    queueLengthWriter,
+                    sp.GetRequiredService<ReceiveAddresses>().MainReceiveAddress));
 
             return Tuple.Create(queueLengthBuffer, queueLengthWriter);
         }


### PR DESCRIPTION
Based on new core changes. 

Metrics aren't supported on send-only endpoints, so relying on `ReceiveAddresses` shouldn't be an issue.