### PR TITLE
Use C# 12 collection expressions

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/EndpointTemplates/DefaultServer.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/EndpointTemplates/DefaultServer.cs
@@ -11,7 +11,7 @@
     {
         public DefaultServer()
         {
-            typesToInclude = new List<Type>();
+            typesToInclude = [];
         }
 
         public DefaultServer(List<Type> typesToInclude)

--- a/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
@@ -235,7 +235,7 @@
                 this.headers = headers;
                 this.metrics = metrics;
 
-                reporters = new List<RawDataReporter>();
+                reporters = [];
             }
 
             protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)


### PR DESCRIPTION
This change satisfies the new `IDE0028` analyzer rules in the .NET 8 SDK.