### PR TITLE
Move in ServiceControl.Monitoring.Data sources

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/MonitoringServer/RawMessage.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/MonitoringServer/RawMessage.cs
@@ -11,10 +11,10 @@
         void Clear()
         {
             Index = InitialIndex;
-            Array.Clear(Entries, 0, MaxEntries);
+            Entries.AsSpan(0, MaxEntries).Clear();
         }
 
-        public Entry[] Entries = new Entry[MaxEntries];
+        public readonly Entry[] Entries = new Entry[MaxEntries];
 
         protected int Index = InitialIndex;
         public const int MaxEntries = 512;

--- a/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/MonitoringServer/TaggedLongValueOccurrenceSerializerDefinition.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.AcceptanceTests/MonitoringServer/TaggedLongValueOccurrenceSerializerDefinition.cs
@@ -11,9 +11,7 @@
     class TaggedLongValueWriterOccurrenceSerializerDefinition : SerializationDefinition
     {
         public override Func<IMessageMapper, IMessageSerializer> Configure(IReadOnlySettings settings)
-        {
-            return mapper => new TaggedLongValueSerializer();
-        }
+            => _ => new TaggedLongValueSerializer();
     }
 
     class ReadOnlyStream : Stream
@@ -58,12 +56,9 @@
 
     class TaggedLongValueSerializer : IMessageSerializer
     {
-        static readonly object[] NoMessages = new object[0];
+        static readonly object[] NoMessages = [];
 
-        public void Serialize(object message, Stream stream)
-        {
-            throw new NotImplementedException();
-        }
+        public void Serialize(object message, Stream stream) => throw new NotImplementedException();
 
         // 0                   1                   2                   3
         // 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1

--- a/src/NServiceBus.Metrics.ServiceControl.Tests/LongValueWriterTests.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/LongValueWriterTests.cs
@@ -1,0 +1,56 @@
+﻿namespace NServiceBus.Metrics.ServiceControl.Tests
+{
+    using NServiceBus.Metrics.ServiceControl;
+    using NUnit.Framework;
+
+    public class LongValueWriterTests : WriterTestBase
+    {
+        public LongValueWriterTests() => SetWriter(LongValueWriterV1.Write);
+
+        [Test]
+        public void Writing_one_value()
+        {
+            const long version = 1L;
+            const long ticks = 2;
+            const long value = 3;
+
+            var entry = new RingBuffer.Entry { Ticks = ticks, Value = value };
+            Write(entry);
+
+            Assert(writer =>
+            {
+                writer.Write(version);
+                writer.Write(ticks);
+                writer.Write(1);
+                writer.Write(0);
+                writer.Write(value);
+            });
+        }
+
+        [Test]
+        public void Writing_two_values_sorted_by_date()
+        {
+            const long version = 1L;
+            const long ticks = 2;
+            const long value1 = 3;
+            const long value2 = value1 + 1;
+            const int timeDiff = 1;
+
+            Write(
+                new RingBuffer.Entry(ticks + timeDiff, value2),
+                new RingBuffer.Entry(ticks, value1)
+                );
+
+            Assert(writer =>
+            {
+                writer.Write(version);
+                writer.Write(ticks);
+                writer.Write(2);
+                writer.Write(0);
+                writer.Write(value1);
+                writer.Write(timeDiff);
+                writer.Write(value2);
+            });
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl.Tests/OccurrenceWriterTests.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/OccurrenceWriterTests.cs
@@ -1,0 +1,50 @@
+﻿namespace NServiceBus.Metrics.ServiceControl.Tests
+{
+    using NServiceBus.Metrics.ServiceControl;
+    using NUnit.Framework;
+
+    public class OccurrenceWriterTests : WriterTestBase
+    {
+        public OccurrenceWriterTests() => SetWriter(OccurrenceWriterV1.Write);
+
+        [Test]
+        public void Writing_one_value()
+        {
+            const long version = 1L;
+            const long ticks = 2;
+
+            var entry = new RingBuffer.Entry { Ticks = ticks, Value = 23544345345 };
+            Write(entry);
+
+            Assert(writer =>
+            {
+                writer.Write(version);
+                writer.Write(ticks);
+                writer.Write(1);
+                writer.Write(0);
+            });
+        }
+
+        [Test]
+        public void Writing_two_values_sorted_by_date()
+        {
+            const long version = 1L;
+            const long ticks = 2;
+            const int timeDiff = 1;
+
+            Write(
+                new RingBuffer.Entry(ticks + timeDiff, 8902374857238758343),
+                new RingBuffer.Entry(ticks, 390489580934859034)
+            );
+
+            Assert(writer =>
+            {
+                writer.Write(version);
+                writer.Write(ticks);
+                writer.Write(2);
+                writer.Write(0);
+                writer.Write(timeDiff);
+            });
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl.Tests/RawDataReporterTests.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/RawDataReporterTests.cs
@@ -1,0 +1,226 @@
+﻿namespace NServiceBus.Metrics.ServiceControl.Tests
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using NServiceBus.Metrics.ServiceControl;
+    using NUnit.Framework;
+
+    public class RawDataReporterTests
+    {
+        RingBuffer buffer;
+        MockSender sender;
+
+        [SetUp]
+        public void SetUp()
+        {
+            buffer = new RingBuffer();
+            sender = new MockSender();
+        }
+
+        [Test]
+        public async Task When_flush_size_is_reached()
+        {
+            var reporter = new RawDataReporter(sender.ReportPayload, buffer, WriteEntriesValues, 4, TimeSpan.MaxValue);
+            reporter.Start();
+            buffer.TryWrite(1);
+            buffer.TryWrite(2);
+            buffer.TryWrite(3);
+            buffer.TryWrite(4);
+
+            AssertValues([1, 2, 3, 4]);
+
+            await reporter.Stop();
+        }
+
+        [Test]
+        public async Task When_flush_size_is_reached_only_maximum_number_is_flushed()
+        {
+            var reporter = new RawDataReporter(sender.ReportPayload, buffer, WriteEntriesValues, 4, TimeSpan.MaxValue);
+            reporter.Start();
+            buffer.TryWrite(1);
+            buffer.TryWrite(2);
+            buffer.TryWrite(3);
+            buffer.TryWrite(4);
+
+            AssertValues([1, 2], [3, 4]);
+
+            await reporter.Stop();
+        }
+
+        [Test]
+        public async Task When_flushing_should_use_parallel_sends()
+        {
+            // this test aims at simulating the consumers that are slow enough to fill parallelism of reporter
+            // it asserts that no progress is done till one of them finishes
+            const int max = RawDataReporter.MaxParallelConsumers;
+
+            var payloads = new ConcurrentQueue<byte[]>();
+            var tcs = new TaskCompletionSource<object>();
+            var semaphore = new SemaphoreSlim(0, max);
+
+            var counter = 0;
+
+            Task Report(byte[] payload, CancellationToken cancellationToken)
+            {
+                var value = ReadValues(payload)[0];
+                if (value < max)
+                {
+                    payloads.Enqueue(payload);
+                    semaphore.Release();
+                    return tcs.Task;
+                }
+
+                payloads.Enqueue(payload);
+                Interlocked.Increment(ref counter);
+                return Task.FromResult(0);
+            }
+
+            var reporter = new RawDataReporter(Report, buffer, WriteEntriesValues, flushSize: 1, maxFlushSize: 1, maxSpinningTime: TimeSpan.MaxValue);
+            reporter.Start();
+
+            for (var i = 0; i < max; i++)
+            {
+                buffer.TryWrite(i);
+            }
+
+            // additional write
+            buffer.TryWrite(max);
+
+            for (var i = 0; i < max; i++)
+            {
+                await semaphore.WaitAsync();
+            }
+
+            // no new reports scheduled before previous complete
+            Assert.That(counter, Is.EqualTo(0));
+
+            // complete all the reports
+            tcs.SetResult("");
+
+            await reporter.Stop();
+
+            // should have run the additional one
+            Assert.That(counter, Is.EqualTo(1));
+            Assert.That(payloads.Count, Is.EqualTo(max + 1));
+        }
+
+        [Test]
+        public async Task When_max_spinning_time_is_reached()
+        {
+            var maxSpinningTime = TimeSpan.FromMilliseconds(100);
+
+            var reporter = new RawDataReporter(sender.ReportPayload, buffer, WriteEntriesValues, int.MaxValue, maxSpinningTime);
+            reporter.Start();
+            buffer.TryWrite(1);
+            buffer.TryWrite(2);
+            await Task.Delay(maxSpinningTime.Add(TimeSpan.FromMilliseconds(200)));
+
+            AssertValues([1, 2]);
+
+            await reporter.Stop();
+        }
+
+        [Test]
+        public async Task When_stopped()
+        {
+            var reporter = new RawDataReporter(sender.ReportPayload, buffer, WriteEntriesValues, int.MaxValue, TimeSpan.MaxValue);
+            reporter.Start();
+            buffer.TryWrite(1);
+            buffer.TryWrite(2);
+
+            await reporter.Stop();
+
+            AssertValues([1, 2]);
+        }
+
+        [Test]
+        public async Task When_high_throughput_endpoint_shuts_down()
+        {
+            const int testSize = 10000;
+            var queue = new ConcurrentQueue<byte[]>();
+
+            Task Send(byte[] data, CancellationToken cancellationToken)
+            {
+                queue.Enqueue(data);
+                return Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken); // delay to make it realistically long
+            }
+
+            var reporter = new RawDataReporter(Send, buffer, WriteEntriesValues);
+            reporter.Start();
+
+            // write values
+            for (var i = 0; i < testSize; i++)
+            {
+                while (buffer.TryWrite(i) == false)
+                {
+                    // spin till it's written
+                }
+            }
+
+            await reporter.Stop();
+
+            var values = new HashSet<long>();
+            foreach (var current in queue.ToArray().Select(ReadValues))
+            {
+                foreach (var v in current)
+                {
+                    values.Add(v);
+                }
+            }
+
+            Assert.That(values.Count, Is.EqualTo(testSize));
+        }
+
+        void AssertValues(params long[][] values)
+        {
+            var bodies = sender.bodies.ToArray();
+            var i = 0;
+            foreach (var body in bodies)
+            {
+                var encodedValues = ReadValues(body);
+                Assert.That(encodedValues, Is.EquivalentTo(values[i]));
+            }
+        }
+
+        static List<long> ReadValues(byte[] body)
+        {
+            var encodedValues = new List<long>();
+            var reader = new BinaryReader(new MemoryStream(body));
+            while (reader.BaseStream.Position < reader.BaseStream.Length)
+            {
+                encodedValues.Add(reader.ReadInt64());
+            }
+            return encodedValues;
+        }
+
+        static void WriteEntriesValues(ArraySegment<RingBuffer.Entry> entries, BinaryWriter writer)
+        {
+            foreach (var entry in entries)
+            {
+                writer.Write(entry.Value);
+            }
+        }
+
+        class MockSender
+        {
+            public List<byte[]> bodies = [];
+
+#pragma warning disable IDE0060 // Remove unused parameter
+            public Task ReportPayload(byte[] body, CancellationToken cancellationToken = default)
+#pragma warning restore IDE0060 // Remove unused parameter
+            {
+                lock (bodies)
+                {
+                    bodies.Add(body);
+                }
+
+                return Task.FromResult(0);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl.Tests/RingBufferTests.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/RingBufferTests.cs
@@ -1,0 +1,170 @@
+﻿namespace NServiceBus.Metrics.ServiceControl.Tests
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+    using NServiceBus.Metrics.ServiceControl;
+    using NUnit.Framework;
+
+    public class RingBufferTests
+    {
+        RingBuffer ringBuffer;
+        const int MaxConsume = 100;
+
+        [SetUp]
+        public void SetUp() => ringBuffer = new RingBuffer();
+
+        [Test]
+        public void Writing_several_entries()
+        {
+            var values = new long[] { 1, 2, 3, 4 };
+
+            WriteValues(values);
+
+            Consume(values);
+            Consume();
+        }
+
+        [Test]
+        public void Writing_over_size_should_not_succeed()
+        {
+            var values = Enumerable.Repeat(1, RingBuffer.Size).Select(i => (long)i).ToArray();
+            WriteValues(values);
+
+            Assert.That(ringBuffer.TryWrite(long.MaxValue), Is.False);
+
+            Consume(values);
+            Consume();
+        }
+
+        [Test]
+        public void Overlapping_buffer_should_be_consumed_till_end_and_again()
+        {
+            var values = Enumerable.Repeat(1, RingBuffer.Size - 2).Select(i => (long)i).ToArray();
+            WriteValues(values);
+            Consume(values);
+            Consume();
+
+            WriteValues(1, 2, 3, 4);
+
+            Consume(1, 2);
+            Consume(3, 4);
+            Consume();
+        }
+
+        [Test]
+        public void Full_write_multiple_times()
+        {
+            var values = Enumerable.Repeat(1, RingBuffer.Size).Select(i => (long)i).ToArray();
+            WriteValues(values);
+            Consume(values);
+            WriteValues(values);
+            Consume(values);
+            WriteValues(values);
+            Consume(values);
+        }
+
+        [Test]
+        public void Estimate_just_initialized_ring_size()
+        {
+            // This test is single threaded so no cross-thread aberrations will be visible.
+            Assert.That(ringBuffer.RoughlyEstimateItemsToConsume(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Estimate_empty_ring_size()
+        {
+            // This test is single threaded so no cross-thread aberrations will be visible.
+            var values = Enumerable.Repeat(1, RingBuffer.Size).Select(i => (long)i).ToArray();
+            WriteValues(values);
+            Consume(values);
+
+            Assert.That(ringBuffer.RoughlyEstimateItemsToConsume(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Estimate_full_ring_size()
+        {
+            // This test is single threaded so no cross-thread aberrations will be visible.
+            var values = Enumerable.Repeat(1, RingBuffer.Size).Select(i => (long)i).ToArray();
+            WriteValues(values);
+
+            Assert.That(ringBuffer.RoughlyEstimateItemsToConsume(), Is.EqualTo(RingBuffer.Size));
+        }
+
+        [Test]
+        public Task Concurrent_test()
+        {
+            const int size = 100000;
+
+            var result = new byte[size * 2];
+
+            var producer1 = Task.Factory.StartNew(() =>
+            {
+                for (var i = 0; i < size; i++)
+                {
+                    while (ringBuffer.TryWrite(i) == false)
+                    {
+                    }
+                }
+            }, TaskCreationOptions.LongRunning);
+
+            var producer2 = Task.Factory.StartNew(() =>
+            {
+                for (var i = 0; i < size; i++)
+                {
+                    while (ringBuffer.TryWrite(i + size) == false)
+                    {
+                    }
+                }
+            }, TaskCreationOptions.LongRunning);
+
+            var consumer = Task.Factory.StartNew(() =>
+            {
+
+                while (true)
+                {
+                    int read;
+
+                    // read till it returns
+                    do
+                    {
+                        read = ringBuffer.Consume(MaxConsume, chunk =>
+                         {
+                             foreach (var value in chunk)
+                             {
+                                 result[value.Value] = 1;
+                             }
+                         });
+                    }
+                    while (read > 0);
+
+                    var completed = result.Count(b => b > 0);
+                    if (completed == result.Length)
+                    {
+                        break;
+                    }
+                }
+            });
+
+            return Task.WhenAll(producer1, producer2, consumer);
+        }
+
+        void Consume(params long[] values)
+        {
+            var read = ringBuffer.Consume(values.Length, entries =>
+            {
+                Assert.That(values, Is.EquivalentTo(entries.Select(e => e.Value).ToArray()));
+            });
+
+            Assert.That(read, Is.EqualTo(values.Length));
+        }
+
+        void WriteValues(params long[] values)
+        {
+            foreach (var value in values)
+            {
+                Assert.That(ringBuffer.TryWrite(value), Is.True);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl.Tests/TaggedLongValueWriterTests.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/TaggedLongValueWriterTests.cs
@@ -1,0 +1,126 @@
+﻿namespace NServiceBus.Metrics.ServiceControl.Tests
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using NServiceBus.Metrics.ServiceControl;
+    using NUnit.Framework;
+
+    public class TaggedLongValueWriterTests : WriterTestBase
+    {
+        static readonly UTF8Encoding NoBom = new UTF8Encoding(false);
+
+        public TaggedLongValueWriterTests() => SetWriter(Write);
+
+        [Test]
+        public void Writing_one_not_tagged_value()
+        {
+            const long version = 1L;
+            const long ticks = 2;
+            const long value = 3;
+
+            var entry = new RingBuffer.Entry { Ticks = ticks, Value = value };
+            Write(entry);
+
+            Assert(writer =>
+            {
+                writer.Write(version);
+                writer.Write(ticks);
+                writer.Write(0); // tag count
+                writer.Write(1); // entry count
+                writer.Write(0);
+                writer.Write(0);
+                writer.Write(value);
+            });
+        }
+
+        [Test]
+        public void Writing_one_tagged_value()
+        {
+            const long version = 1L;
+            const long ticks = 13123;
+            const long value = 1345347;
+
+            const string tagName = "this is a test tag value 111!!!";
+            var tagId = writer.GetTagId(tagName);
+            var bytes = NoBom.GetBytes(tagName);
+
+            var entry = new RingBuffer.Entry { Ticks = ticks, Value = value, Tag = tagId };
+            Write(entry);
+
+            Assert(writer =>
+            {
+                writer.Write(version);
+                writer.Write(ticks);
+
+                writer.Write(1); // tag count
+
+                // tag entry
+                writer.Write(tagId);
+                writer.Write(bytes.Length);
+                writer.Write(bytes);
+
+                writer.Write(1); // entry count
+                writer.Write(0);
+                writer.Write(tagId);
+                writer.Write(value);
+            });
+        }
+
+        [Test]
+        public void Writing_two_tagged_values_sorted_by_date()
+        {
+            const long version = 1L;
+            const long ticks = 334346347;
+            const long value1 = 983745897384573;
+            const long value2 = value1 + 1;
+            const int timeDiff = 1;
+
+            const string tagName1 = "this is a test tag value 111!!!";
+            var tagId1 = writer.GetTagId(tagName1);
+            var bytes1 = NoBom.GetBytes(tagName1);
+
+            const string tagName2 = "this is another test tag value 222@@@ Even longer than the first one!";
+            var tagId2 = writer.GetTagId(tagName2);
+            var bytes2 = NoBom.GetBytes(tagName2);
+
+            Write(
+                new RingBuffer.Entry(ticks + timeDiff, value2, tagId2),
+                new RingBuffer.Entry(ticks, value1, tagId1)
+            );
+
+            Assert(writer =>
+            {
+                writer.Write(version);
+                writer.Write(ticks);
+
+                writer.Write(2); // tag count
+
+                // tag1
+                writer.Write(tagId1);
+                writer.Write(bytes1.Length);
+                writer.Write(bytes1);
+
+                // tag2
+                writer.Write(tagId2);
+                writer.Write(bytes2.Length);
+                writer.Write(bytes2);
+
+                writer.Write(2);
+                writer.Write(0);
+                writer.Write(tagId1);
+                writer.Write(value1);
+                writer.Write(timeDiff);
+                writer.Write(tagId2);
+                writer.Write(value2);
+            });
+        }
+
+        [SetUp]
+        public new void SetUp() => writer = new TaggedLongValueWriterV1();
+
+        void Write(BinaryWriter outputWriter, ArraySegment<RingBuffer.Entry> entries) => writer.Write(outputWriter, entries);
+
+        TaggedLongValueWriterV1 writer;
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl.Tests/WriterTestBase.cs
+++ b/src/NServiceBus.Metrics.ServiceControl.Tests/WriterTestBase.cs
@@ -1,0 +1,61 @@
+namespace NServiceBus.Metrics.ServiceControl.Tests
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using NServiceBus.Metrics.ServiceControl;
+    using NUnit.Framework;
+
+    public abstract class WriterTestBase
+    {
+        MemoryStream ms;
+        BinaryWriter bw;
+        Action<BinaryWriter, ArraySegment<RingBuffer.Entry>> writer;
+
+        internal WriterTestBase()
+        {
+            ms = new MemoryStream();
+            bw = new BinaryWriter(ms);
+        }
+
+        internal void SetWriter(Action<BinaryWriter, ArraySegment<RingBuffer.Entry>> writer) => this.writer = writer;
+
+        [SetUp]
+        public void SetUp()
+        {
+            bw.Flush();
+            ms.SetLength(0);
+        }
+
+        internal void Write(params RingBuffer.Entry[] entries)
+        {
+            // put additional values in front and at the end to make it a real segment
+            var list = entries.ToList();
+            list.Insert(0, new RingBuffer.Entry());
+            list.Add(new RingBuffer.Entry());
+
+            writer(bw, new ArraySegment<RingBuffer.Entry>([.. list], 1, entries.Length));
+
+            bw.Flush();
+        }
+
+        protected void Assert(Action<BinaryWriter> write)
+        {
+            using var stream = new MemoryStream();
+            using (var binaryWriter = new BinaryWriter(stream))
+            {
+                write(binaryWriter);
+                binaryWriter.Flush();
+            }
+
+            NUnit.Framework.Assert.That(stream.ToArray(), Is.EquivalentTo(ms.ToArray()));
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            bw?.Dispose();
+            ms?.Dispose();
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl/EntryTickComparer.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/EntryTickComparer.cs
@@ -1,0 +1,13 @@
+﻿namespace NServiceBus.Metrics.ServiceControl
+{
+    using System.Collections.Generic;
+
+    sealed class EntryTickComparer : IComparer<RingBuffer.Entry>
+    {
+        public static readonly EntryTickComparer Instance = new EntryTickComparer();
+
+        EntryTickComparer() { }
+
+        public int Compare(RingBuffer.Entry x, RingBuffer.Entry y) => x.Ticks.CompareTo(y.Ticks);
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl/IReportNativeQueueLength.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/IReportNativeQueueLength.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Metrics.ServiceControl
 {
     using System.Collections.Generic;
-    using global::ServiceControl.Monitoring.Data;
 
     /// <summary>
     /// Reports native queue length to ServiceControl Monitoring
@@ -19,24 +18,17 @@
         IEnumerable<string> MonitoredQueues { get; }
     }
 
-    class QueueLengthBufferReporter : IReportNativeQueueLength
+    sealed class QueueLengthBufferReporter(
+        RingBuffer buffer,
+        TaggedLongValueWriterV1 writer,
+        params string[] monitoredQueues)
+        : IReportNativeQueueLength
     {
-        RingBuffer buffer;
-        TaggedLongValueWriterV1 writer;
-        string[] monitoredQueues;
-
-        public QueueLengthBufferReporter(RingBuffer buffer, TaggedLongValueWriterV1 writer, params string[] monitoredQueues)
-        {
-            this.buffer = buffer;
-            this.writer = writer;
-            this.monitoredQueues = monitoredQueues;
-        }
-
         public void ReportQueueLength(string physicalQueueName, long queueLength)
         {
             var tag = writer.GetTagId(physicalQueueName);
 
-            RingBufferExtensions.WriteTaggedValue(buffer, "QueueLength", queueLength, tag);
+            buffer.WriteTaggedValue("QueueLength", queueLength, tag);
         }
 
         public IEnumerable<string> MonitoredQueues => monitoredQueues;

--- a/src/NServiceBus.Metrics.ServiceControl/LongValueWriterV1.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/LongValueWriterV1.cs
@@ -1,0 +1,42 @@
+﻿namespace NServiceBus.Metrics.ServiceControl
+{
+    using System;
+    using System.IO;
+
+    static class LongValueWriterV1
+    {
+        const long Version = 1;
+
+        // WIRE FORMAT, Version: 1
+
+        // 0                   1                   2                   3
+        // 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        //|     Version   | Min date time | count | date1 |     value 1   |
+        //+-------+-------+-------+-------+---------------+-------+-------+
+        //| date2 |   value  2    | date3 |     value 3   | date4 | ...   |
+        //+-------+---------------+-------+---------------+-------+-------+
+        public static void Write(BinaryWriter outputWriter, ArraySegment<RingBuffer.Entry> chunk)
+        {
+            var array = chunk.Array;
+            var offset = chunk.Offset;
+            var count = chunk.Count;
+
+            Array.Sort(array, offset, count, EntryTickComparer.Instance);
+
+            var minDate = array[offset].Ticks;
+
+            outputWriter.Write(Version);
+            outputWriter.Write(minDate);
+            outputWriter.Write(count);
+
+            for (var i = 0; i < count; i++)
+            {
+                // int allows to write ticks of 7minutes, as reporter runs much more frequent, this can be int
+                var date = (int)(array[offset + i].Ticks - minDate);
+                outputWriter.Write(date);
+                outputWriter.Write(array[offset + i].Value);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl/NServiceBus.Metrics.ServiceControl.csproj
+++ b/src/NServiceBus.Metrics.ServiceControl/NServiceBus.Metrics.ServiceControl.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="NServiceBus" Version="[9.0.0, 10.0.0)" />
     <PackageReference Include="NServiceBus.Metrics" Version="[5.0.0, 6.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="ServiceControl.Monitoring.Data" Version="3.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Metrics.ServiceControl/OccurrenceWriterV1.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/OccurrenceWriterV1.cs
@@ -1,0 +1,42 @@
+namespace NServiceBus.Metrics.ServiceControl
+{
+    using System;
+    using System.IO;
+
+    static class OccurrenceWriterV1
+    {
+        const long Version = 1;
+
+        // WIRE FORMAT, Version: 1
+
+        //0                   1                   2                   3
+        //0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        //|     Version   | Base ticks    | count | date1 | date2 | date3 |
+        //+---------------+---------------+-------------------------------+
+        //| date4 | date5 | date6 | date7 | date8 | ...
+        //+---------------+---------------+-------------------------------+
+        //| ....
+        public static void Write(BinaryWriter outputWriter, ArraySegment<RingBuffer.Entry> chunk)
+        {
+            var array = chunk.Array;
+            var offset = chunk.Offset;
+            var count = chunk.Count;
+
+            Array.Sort(array, offset, count, EntryTickComparer.Instance);
+
+            var minDate = array[offset].Ticks;
+
+            outputWriter.Write(Version);
+            outputWriter.Write(minDate);
+            outputWriter.Write(count);
+
+            for (var i = 0; i < count; i++)
+            {
+                // int allows to write ticks of 7minutes, as reporter runs much more frequent, this can be int
+                var date = (int)(array[offset + i].Ticks - minDate);
+                outputWriter.Write(date);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl/RawDataReporter.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/RawDataReporter.cs
@@ -1,0 +1,148 @@
+﻿namespace NServiceBus.Metrics.ServiceControl
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    delegate void WriteOutput(ArraySegment<RingBuffer.Entry> entries, BinaryWriter outputWriter);
+
+    class RawDataReporter : IDisposable
+    {
+        const int DefaultFlushSize = 1028; // for entries written on 16bytes this will give 16kB
+        const int MaxDefaultFlushSize = 2048; // for entries written on 16byte this will give 32kB
+        internal const int MaxParallelConsumers = 4;
+        readonly RingBuffer buffer;
+        readonly int flushSize;
+        readonly int maxFlushSize;
+        readonly Action<ArraySegment<RingBuffer.Entry>> outputWriter;
+        readonly BinaryWriter writer;
+        readonly MemoryStream memoryStream;
+        readonly CancellationTokenSource stopReporterTokenSource;
+        readonly TimeSpan maxSpinningTime;
+        readonly Func<byte[], CancellationToken, Task> sender;
+        readonly CancellationTokenSource cancelReportingTokenSource;
+        Task reporter;
+
+        static readonly TimeSpan DefaultMaxSpinningTime = TimeSpan.FromSeconds(5);
+        static readonly TimeSpan singleSpinningTime = TimeSpan.FromMilliseconds(50);
+
+        public RawDataReporter(Func<byte[], CancellationToken, Task> sender, RingBuffer buffer, WriteOutput outputWriter)
+            : this(sender, buffer, outputWriter, DefaultFlushSize, DefaultMaxSpinningTime)
+        {
+        }
+
+        public RawDataReporter(Func<byte[], CancellationToken, Task> sender, RingBuffer buffer, WriteOutput outputWriter, int flushSize, TimeSpan maxSpinningTime)
+            : this(sender, buffer, outputWriter, flushSize, MaxDefaultFlushSize, maxSpinningTime)
+        {
+
+        }
+
+        public RawDataReporter(Func<byte[], CancellationToken, Task> sender, RingBuffer buffer, WriteOutput outputWriter, int flushSize, int maxFlushSize, TimeSpan maxSpinningTime)
+        {
+            this.buffer = buffer;
+            this.flushSize = flushSize;
+            this.maxFlushSize = maxFlushSize;
+            this.maxSpinningTime = maxSpinningTime;
+            this.outputWriter = entries => outputWriter(entries, writer);
+            this.sender = sender;
+            memoryStream = new MemoryStream();
+            writer = new BinaryWriter(memoryStream);
+            stopReporterTokenSource = new CancellationTokenSource();
+            cancelReportingTokenSource = new CancellationTokenSource();
+        }
+
+        public void Start()
+        {
+            reporter = Task.Run(async () =>
+            {
+                var consumers = new List<Task>(MaxParallelConsumers + 1);
+
+                while (!stopReporterTokenSource.IsCancellationRequested)
+                {
+                    var totalSpinningTime = TimeSpan.Zero;
+
+                    // spin till either MaxSpinningTime is reached OR items to consume are more than FlushSize
+                    while (totalSpinningTime < maxSpinningTime)
+                    {
+                        if (stopReporterTokenSource.IsCancellationRequested)
+                        {
+                            break;
+                        }
+
+                        var itemsToConsume = buffer.RoughlyEstimateItemsToConsume();
+                        if (itemsToConsume >= flushSize)
+                        {
+                            break;
+                        }
+
+                        totalSpinningTime += singleSpinningTime;
+                        await Task.Delay(singleSpinningTime, cancelReportingTokenSource.Token).ConfigureAwait(false);
+                    }
+
+                    if (consumers.Count >= MaxParallelConsumers)
+                    {
+                        var task = await Task.WhenAny(consumers).ConfigureAwait(false);
+                        consumers.Remove(task);
+                    }
+
+                    consumers.Add(Consume(cancelReportingTokenSource.Token));
+                }
+
+                // await all the flushes
+                await Task.WhenAll(consumers).ConfigureAwait(false);
+
+                // consume leftovers
+                var consumed = buffer.Consume(maxFlushSize, outputWriter);
+                while (consumed > 0)
+                {
+                    await Flush(cancelReportingTokenSource.Token).ConfigureAwait(false);
+                    consumed = buffer.Consume(maxFlushSize, outputWriter);
+                }
+            });
+        }
+
+        Task Consume(CancellationToken cancellationToken)
+        {
+            var consumed = buffer.Consume(maxFlushSize, outputWriter);
+
+            if (consumed > 0)
+            {
+                return Flush(cancellationToken);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        Task Flush(CancellationToken cancellationToken)
+        {
+            writer.Flush();
+            // if only transport operation allowed ArraySegment<byte>...
+            var body = memoryStream.ToArray();
+
+            // clean stream
+            memoryStream.SetLength(0);
+
+            return sender(body, cancellationToken);
+        }
+
+        public async Task Stop(CancellationToken cancellationToken = default)
+        {
+            stopReporterTokenSource.Cancel();
+
+            using (cancellationToken.Register(() => cancelReportingTokenSource.Cancel()))
+            {
+                await reporter.ConfigureAwait(false);
+            }
+        }
+
+        public void Dispose()
+        {
+            writer?.Dispose();
+            memoryStream?.Dispose();
+            stopReporterTokenSource?.Dispose();
+            cancelReportingTokenSource?.Dispose();
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
@@ -6,7 +6,6 @@
     using System.Threading;
     using System.Threading.Tasks;
     using Features;
-    using global::ServiceControl.Monitoring.Data;
     using Hosting;
     using Logging;
     using MessageMutator;
@@ -17,7 +16,7 @@
     using Support;
     using Transport;
 
-    class ReportingFeature : Feature
+    sealed class ReportingFeature : Feature
     {
         public ReportingFeature()
         {

--- a/src/NServiceBus.Metrics.ServiceControl/RingBuffer.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/RingBuffer.cs
@@ -96,7 +96,7 @@
             }
 
             onChunk(new ArraySegment<Entry>(entries, indexStart, length));
-            Array.Clear(entries, indexStart, length);
+            entries.AsSpan(indexStart, length).Clear();
 
             Interlocked.Add(ref nextToConsume, length);
             return length;

--- a/src/NServiceBus.Metrics.ServiceControl/RingBuffer.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/RingBuffer.cs
@@ -1,0 +1,105 @@
+﻿namespace NServiceBus.Metrics.ServiceControl
+{
+    using System;
+    using System.Threading;
+
+    sealed class RingBuffer
+    {
+        internal const int Size = 4096;
+        const long SizeMask = Size - 1;
+        const long EpochMask = ~SizeMask;
+
+        long nextToWrite;
+        long nextToConsume;
+
+        Entry[] entries = new Entry[Size];
+
+        public struct Entry(long ticks, long value, int tag = 0)
+        {
+            public long Ticks = ticks;
+            public long Value = value;
+            public int Tag = tag;
+        }
+
+        public bool TryWrite(long value, int tag = 0)
+        {
+            var readNextWrite = Volatile.Read(ref nextToWrite);
+            long index;
+
+            do
+            {
+                var consume = Volatile.Read(ref nextToConsume);
+
+                // if writers overlaps with not consumed writes, end
+                if (readNextWrite - consume >= Size)
+                {
+                    return false;
+                }
+                index = readNextWrite;
+
+                // try to swap nextToWrite
+                readNextWrite = Interlocked.CompareExchange(ref nextToWrite, index + 1, index);
+
+                // do until the swap not succeeded
+            }
+            while (index != readNextWrite);
+
+            // index is claimed, writing data
+            var i = index & SizeMask;
+            var ticks = DateTime.UtcNow.Ticks;
+
+            entries[i].Value = value;
+            entries[i].Tag = tag;
+
+            Volatile.Write(ref entries[i].Ticks, ticks);
+
+            return true;
+        }
+
+        internal long RoughlyEstimateItemsToConsume() => Volatile.Read(ref nextToWrite) - Volatile.Read(ref nextToConsume);
+
+        // Consumes a chunk of entries. This method will call onChunk zero, or one time. No multiple calls will be issued.
+        internal int Consume(int maxFlushSize, Action<ArraySegment<Entry>> onChunk)
+        {
+            var consume = Interlocked.CompareExchange(ref nextToConsume, 0, 0);
+            var max = Volatile.Read(ref nextToWrite);
+
+            var i = consume;
+
+            // The epoch identifies the id of the current passage over the circular buffer.
+            // This is used to ensure, that once the Consume goes over the edge of the buffer,
+            // and starts from the beginning, this part won't be included in the result passed to onChunk.
+            // If it was, this could not be represented as a continuous ArraySegment<Entry>.
+            //
+            // Example:
+            // To consume a buffer with following values [5, 6, null, 4] the consumer would first consume
+            // a segment [4] followed by consumption of [5, 6] in the next Consume call.
+            var epoch = i & EpochMask;
+            var length = 0;
+            while (Volatile.Read(ref entries[i & SizeMask].Ticks) > 0 && i < max && length < maxFlushSize)
+            {
+                if ((i & EpochMask) != epoch)
+                {
+                    break;
+                }
+
+                length++;
+                i++;
+            }
+
+            // [consume, i) - entries to process
+            var indexStart = (int)(consume & SizeMask);
+
+            if (length == 0)
+            {
+                return 0;
+            }
+
+            onChunk(new ArraySegment<Entry>(entries, indexStart, length));
+            Array.Clear(entries, indexStart, length);
+
+            Interlocked.Add(ref nextToConsume, length);
+            return length;
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/EndpointMetadata.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/EndpointMetadata.cs
@@ -6,18 +6,13 @@
     {
         readonly string localAddress;
 
-        public EndpointMetadata(string localAddress)
-        {
-            this.localAddress = localAddress;
-        }
+        public EndpointMetadata(string localAddress) => this.localAddress = localAddress;
 
-        public string ToJson()
-        {
-            return JsonSerializer.Serialize(new
+        public string ToJson() =>
+            JsonSerializer.Serialize(new
             {
                 PluginVersion = 3,
                 LocalAddress = localAddress
             });
-        }
     }
 }

--- a/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/NServiceBusMetadataReport.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ServiceControlReporting/NServiceBusMetadataReport.cs
@@ -42,7 +42,7 @@
             }
             catch (Exception ex) when (!ex.IsCausedBy(cancellationToken))
             {
-                log.Error($"Error while sending metric data to {destination.Destination}.", ex);
+                Log.Error($"Error while sending metric data to {destination.Destination}.", ex);
             }
         }
 
@@ -52,6 +52,6 @@
         readonly EndpointMetadata endpointMetadata;
         readonly TimeSpan timeToBeReceived;
 
-        static ILog log = LogManager.GetLogger<NServiceBusMetadataReport>();
+        static readonly ILog Log = LogManager.GetLogger<NServiceBusMetadataReport>();
     }
 }

--- a/src/NServiceBus.Metrics.ServiceControl/TaggedLongValueWriterV1.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/TaggedLongValueWriterV1.cs
@@ -1,0 +1,102 @@
+﻿namespace NServiceBus.Metrics.ServiceControl
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+    using System.Threading;
+
+    /// <summary>
+    /// This writer provides a protocol for writing string-tagged values.
+    /// The tags are written as a dictionary at the beginning of the payload, which enables reading it to a local dictionary and performing a fast transformation for the reader.
+    /// </summary>
+    sealed class TaggedLongValueWriterV1
+    {
+        const long Version = 1;
+
+        static readonly UTF8Encoding NoBom = new UTF8Encoding(false);
+        readonly ConcurrentDictionary<string, Tag> byTagName = new ConcurrentDictionary<string, Tag>();
+        readonly ConcurrentDictionary<int, Tag> byTagId = new ConcurrentDictionary<int, Tag>();
+        readonly Func<string, Tag> GenerateTag;
+        int generator;
+
+        public TaggedLongValueWriterV1() =>
+            GenerateTag = str =>
+            {
+                var id = Interlocked.Increment(ref generator);
+                var tag = new Tag(str, id);
+                byTagId[id] = tag;
+                return tag;
+            };
+
+        // WIRE FORMAT, Version: 1
+
+        // 0                   1                   2                   3
+        // 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        //|     Version   | Min date time |tag cnt|tag1key|tag1len| tag1..|
+        //+-------+-------+-------+-------+---------------+-------+-------+
+        //| ..bytes       |tag2key|tag2len| tag2 bytes .................  |
+        //+-------+-------+-------+-------+---------------+-------+-------+
+        //| tag2 bytes continued                  | count | date1 | tag1  |
+        //+-------+-------+-------+-------+---------------+-------+-------+
+        //|    value 1    | date2 | tag2  |     value 2   | date3 | ...   |
+        //+-------+---------------+-------+---------------+-------+-------+
+        public void Write(BinaryWriter outputWriter, ArraySegment<RingBuffer.Entry> chunk)
+        {
+            var array = chunk.Array;
+            var offset = chunk.Offset;
+            var count = chunk.Count;
+
+            Array.Sort(array, offset, count, EntryTickComparer.Instance);
+
+            var minDate = array[offset].Ticks;
+
+            outputWriter.Write(Version);
+            outputWriter.Write(minDate);
+
+            WriteTags(outputWriter, count, array, offset);
+
+            outputWriter.Write(count);
+
+            for (var i = 0; i < count; i++)
+            {
+                // int allows to write ticks of 7minutes, as reporter runs much more frequent, this can be int
+                var date = (int)(array[offset + i].Ticks - minDate);
+                outputWriter.Write(date);
+                outputWriter.Write(array[offset + i].Tag);
+                outputWriter.Write(array[offset + i].Value);
+            }
+        }
+
+        void WriteTags(BinaryWriter outputWriter, int count, RingBuffer.Entry[] array, int offset)
+        {
+            var tags = new Dictionary<int, Tag>();
+            for (var i = 0; i < count; i++)
+            {
+                var tag = array[offset + i].Tag;
+                if (tag > 0 && tags.ContainsKey(tag) == false)
+                {
+                    tags[tag] = byTagId[tag];
+                }
+            }
+
+            outputWriter.Write(tags.Count);
+            foreach (var tag in tags)
+            {
+                outputWriter.Write(tag.Key);
+                outputWriter.Write(tag.Value.Bytes.Length);
+                outputWriter.Write(tag.Value.Bytes);
+            }
+        }
+
+        public int GetTagId(string tagName) => byTagName.GetOrAdd(tagName, GenerateTag).ID;
+
+        class Tag(string tag, int id)
+        {
+            public int ID { get; } = id;
+            public byte[] Bytes { get; } = NoBom.GetBytes(tag);
+        }
+    }
+}


### PR DESCRIPTION
[ServiceControl.Monitoring.Data](https://github.com/Particular/ServiceControl.Monitoring.Data) was originally designed to be a source package that can be used to write data to binary writers and then forward it to specific destinations. We never go past the ServiceControl as a destination in terms of usage. It is time to move the sources in and archive the package, especially considering System.Diagnostics.Meters is the future of metrics. 

Should it turn out, we have more needs for [ServiceControl.Monitoring.Data](https://github.com/Particular/ServiceControl.Monitoring.Data) this decision is easily revertible by:

- Unarchiving the ServiceControl.Monitoring.Data repository
- Flip NServiceBus.Metrics.ServiceControl back to using the source package
- Restore the deployment pipeline