### PR TITLE
register monitoring queue for use in core manifest output

### DIFF
--- a/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
@@ -34,6 +34,16 @@
                 var address = reportingOptions.ServiceControlMetricsAddress;
                 return string.IsNullOrEmpty(address) == false;
             }, $"Reporting is enabled by calling '{nameof(MetricsOptionsExtensions.SendMetricDataToServiceControl)}'");
+
+            Defaults(settings =>
+            {
+                var options = settings.GetOrDefault<MetricsOptions>();
+                if (options != null)
+                {
+                    var reportingOptions = ReportingOptions.Get(options);
+                    settings.Set("NServiceBus.Metrics.ServiceControl.MetricsAddress", reportingOptions.ServiceControlMetricsAddress);
+                }
+            });
         }
 
         protected override void Setup(FeatureConfigurationContext context)

--- a/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
+++ b/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs
@@ -42,6 +42,10 @@
                 {
                     var reportingOptions = ReportingOptions.Get(options);
                     settings.Set("NServiceBus.Metrics.ServiceControl.MetricsAddress", reportingOptions.ServiceControlMetricsAddress);
+                    if (settings.TryGet<ManifestItems>(out var manifest))
+                    {
+                        manifest.Add("monitoringQueue", reportingOptions.ServiceControlMetricsAddress);
+                    }
                 }
             });
         }


### PR DESCRIPTION
the name of the queue used for monitoring is information that is useful for other features (e.g. https://github.com/Particular/NServiceBus/issues/7370). This change makes it directly available in the `SettingsHolder`, although there are [potentially more desirable methods of achieving this](https://github.com/Particular/NServiceBus.Metrics.ServiceControl/issues/674) that require more significant refactoring

additionally added the monitoring queue to the manifest for https://github.com/Particular/NServiceBus/pull/7406